### PR TITLE
Fix capitalisation of 'John' in Project Gutenberg dictionary

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -376,7 +376,7 @@
 "KWR": "why",
 "HEUPBD": "behind",
 "PWAEUPL": "became",
-"SKWROPB": "john",
+"SKWROPB": "John",
 "PW-BG": "become",
 "TKED": "dead",
 "*ERT": "earth",


### PR DESCRIPTION
A change in capitalisation for "John" in the Project Gutenberg dictionary entry for `SKWROPB` would bring it in line with all the other dictionaries. For example:

https://github.com/didoesdigital/steno-dictionaries/blob/5eaf4f5fb55e422c00aad2df8f34d5a9552dca0a/dictionaries/top-10000-english-words.json#L373

https://github.com/didoesdigital/steno-dictionaries/blob/5eaf4f5fb55e422c00aad2df8f34d5a9552dca0a/dictionaries/top-1000-words.json#L379

