### PR TITLE
Fix capitalisation in keystroke for 'Sn'

### DIFF
--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -421,7 +421,7 @@
 "HREUF": "live",
 "HRA*ED": "lady",
 "SUBT": "subject",
-"S*/TPH*": "Sn",
+"S*P/TPH*": "Sn",
 "AEPBS": "answer",
 "SAE": "sea",
 "TPAOER": "fear",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -421,7 +421,7 @@
 "HREUF": "live",
 "HRA*ED": "lady",
 "SUBT": "subject",
-"S*/TPH*": "Sn",
+"S*P/TPH*": "Sn",
 "AEPBS": "answer",
 "SAE": "sea",
 "TPAOER": "fear",


### PR DESCRIPTION
`S*/TPH*` outputs "sn" in lowercase, so fix the capitalisation of the "Sn" entry to `S*K/TPH*`.