### PR TITLE
Fix entries for 'er' and 'ye'

### DIFF
--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -449,7 +449,7 @@
 "SHOE": "show",
 "PAERT": "party",
 "TPAOEUPB": "fine",
-"KWR*/*E/SP-S": "ye",
+"KWR*/*E": "ye",
 "R-D": "ready",
 "STOER": "story",
 "KPHOPB": "common",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -365,7 +365,7 @@
 "SEFRL": "several",
 "PWEUS": "business",
 "WHR": "whether",
-"ER/SP-S": "er",
+"*E/R*": "er",
 "PHAERPB": "manner",
 "SEBGD": "second",
 "R-PB": "reason",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -4124,7 +4124,7 @@
 "TKERPLGS": "determination",
 "APB/PHAEUGS": "animation",
 "OR/K-L": "oracle",
-"ER/SP-S": "er",
+"*E/R*": "er",
 "PH*T/AOU": "Matthew",
 "HRAOES": "lease",
 "PROUBGS/-S": "productions",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -6192,7 +6192,7 @@
 "TKRAUGS": "drawings",
 "SEUGS": "significance",
 "SPHOEUR": "scenario",
-"KWR*/*E/SP-S": "ye",
+"KWR*/*E": "ye",
 "TP*/SP-S/-S": "fs",
 "HRUFRS": "lovers",
 "A/TOPL/EUBG": "atomic",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -449,7 +449,7 @@
 "SHOE": "show",
 "PAERT": "party",
 "TPAOEUPB": "fine",
-"KWR*/*E/SP-S": "ye",
+"KWR*/*E": "ye",
 "R-D": "ready",
 "STOER": "story",
 "KPHOPB": "common",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -365,7 +365,7 @@
 "SEFRL": "several",
 "PWEUS": "business",
 "WHR": "whether",
-"ER/SP-S": "er",
+"*E/R*": "er",
 "PHAERPB": "manner",
 "SEBGD": "second",
 "R-PB": "reason",


### PR DESCRIPTION
Change keystroke for 'er' to its finger-spelling, and remove trailing `SP-S` from keystroke for 'ye'.

Fixes #7