### PR TITLE
Change "faith" stroke from PHA*EUT to TPA*EUT

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -53762,7 +53762,6 @@
 "PHA*EURPB": "migraine",
 "PHA*EURT/TK*P": "maitre d'",
 "PHA*EUS/O*PB": "maison",
-"PHA*EUT": "faith",
 "PHA*EUZ": "maze",
 "PHA*F/REUBG": "maverick",
 "PHA*FBG": "masque",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -611,7 +611,7 @@
 "P-PB": "opinion",
 "WOEUPBD": "window",
 "RAPB": "ran",
-"PHA*EUT": "faith",
+"TPA*EUT": "faith",
 "AG": "ago",
 "KWRAOEPLT": "agreement",
 "KHARPBLG": "charge",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -2239,7 +2239,7 @@
 "KOPBG": "Kong",
 "KHRUPL": "column",
 "PHRAPBTS": "plants",
-"PHA*EUT": "faith",
+"TPA*EUT": "faith",
 "KHAEUPB": "chain",
 "SHR*ER": "developer",
 "AOEUFD": "identify",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -611,7 +611,7 @@
 "P-PB": "opinion",
 "WOEUPBD": "window",
 "RAPB": "ran",
-"PHA*EUT": "faith",
+"TPA*EUT": "faith",
 "AG": "ago",
 "KWRAOEPLT": "agreement",
 "KHARPBLG": "charge",


### PR DESCRIPTION
In the Plover dictionary for release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), `PHA*EUT` outputs "m8", so this pull requests proposes to:

- Remove `PHA*EUT` from `dict.json` as a stroke for "faith", since it would seem it's no longer correct
- Change the keystroke in all dictionary references for "faith" to `TPA*EUT`