### PR TITLE
Replace keystroke for 'entered' from SPWR-D to *EPBTD

### DIFF
--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -517,7 +517,7 @@
 "POGS": "position",
 "SOUPBD": "sound",
 "TPHOPB": "none",
-"SPWR-D": "entered",
+"*EPBTD": "entered",
 "KHRAOER": "clear",
 "RAOD": "road",
 "HRAEUT": "late",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -3226,7 +3226,7 @@
 "SAOEUSZ": "sizes",
 "PHRAEUPB": "plain",
 "KPEUT": "exit",
-"SPWR-D": "entered",
+"*EPBTD": "entered",
 "EUR/APB": "Iran",
 "ARPL": "arm",
 "KAOES": "keys",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -517,7 +517,7 @@
 "POGS": "position",
 "SOUPBD": "sound",
 "TPHOPB": "none",
-"SPWR-D": "entered",
+"*EPBTD": "entered",
 "KHRAOER": "clear",
 "RAOD": "road",
 "HRAEUT": "late",


### PR DESCRIPTION
This pull request doesn't represent an error or mistake, but more a subjective opinion, so I wouldn't mind if it got rejected.

I found while using Typey-Type that the `*EPBTD` stroke for "entered" was more intuitive than the current (valid) stroke of `SPWR-D`.

Both strokes, at least for my hands, felt about the same when it came to ease of performing the stroke (slightly awkward), but I found `*EPBTD` easier to remember since it more accurately matched the phonetics of the word. So, I'm proposing this change.