### PR TITLE
Stroke KHARLS rather than KHARLZ for "Charles" in Typey-Type

### DIFF
--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -825,7 +825,7 @@
 "PAOES": "piece",
 "PWREURB": "British",
 "EBGS": "ex",
-"KHARLZ": "Charles",
+"KHARLS": "Charles",
 "TPORPLD": "formed",
 "SPAOEG": "speaking",
 "TRAOEUG": "trying",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -1846,7 +1846,7 @@
 "TKEUFRPBS": "difference",
 "HRO*UD": "allowed",
 "KRERBG": "correct",
-"KHARLZ": "Charles",
+"KHARLS": "Charles",
 "TPHA*EUGS": "nation",
 "SELG": "selling",
 "HROTS": "lots",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -825,7 +825,7 @@
 "PAOES": "piece",
 "PWREURB": "British",
 "EBGS": "ex",
-"KHARLZ": "Charles",
+"KHARLS": "Charles",
 "TPORPLD": "formed",
 "SPAOEG": "speaking",
 "TRAOEUG": "trying",


### PR DESCRIPTION
Although both `KHARLS` and `KHARLZ` are valid strokes for "Charles" in Plover, I propose to substitute its entry from `KHARLZ` to `KHARLS` in Typey-Type because:

- It's easier to stroke (your pinky doesn't need to reach for `Z`)
- Phonetically, the name "Charles" doesn't necessarily end with a strong "Z" sound