### PR TITLE
Change 'honour' dictionary entries to US spelling

### DIFF
--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -844,7 +844,7 @@
 "KR-BL": "considerable",
 "KR*": "c",
 "PWROEBG": "broke",
-"HO*URPB": "honour",
+"HO*RPB": "honor",
 "SEFPB": "seven",
 "PRAOEUFT": "private",
 "SEUT": "sit",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -844,7 +844,7 @@
 "KR-BL": "considerable",
 "KR*": "c",
 "PWROEBG": "broke",
-"HO*URPB": "honour",
+"HO*RPB": "honor",
 "SEFPB": "seven",
 "PRAOEUFT": "private",
 "SEUT": "sit",


### PR DESCRIPTION
Although I don't necessarily agree with the content of this PR on principle, since I'm personally a user of non-US spelling, Plover itself is US-English based. Therefore, anyone learning steno using Typey-Type, having installed only the default Plover dictionaries, will encounter un-stroke-able words when they deviate from US spelling.

Default Plover does not have an entry for `"HO*URPB": "honour"`, so the only way to stroke this entry in Typey-Type to progress forward, is to stroke something like `HOPB/OUR`, or finger-spell. Therefore, I propose to changing out the entry for "honour" to `HO*RPB": "honor"`.