### PR TITLE
Fix stroke for "etc."

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -244,7 +244,6 @@
 "WAOEUFS": "wives",
 "APB/AE": "an'",
 "KR*/TP-PL": "c.",
-"*ETS": "etc.",
 "O*/AE": "o'",
 "5R/TP-PL": "v.",
 "KEUPBG/AES": "king's",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -244,7 +244,7 @@
 "WAOEUFS": "wives",
 "APB/AE": "an'",
 "KR*/TP-PL": "c.",
-"ETS/TP-PL": "etc.",
+"*ETS": "etc.",
 "O*/AE": "o'",
 "5R/TP-PL": "v.",
 "KEUPBG/AES": "king's",

--- a/dictionaries/nouns.json
+++ b/dictionaries/nouns.json
@@ -380,6 +380,7 @@
 "PWO*": "bo",
 "*ED": "ed",
 "*EF": "ef",
+"*ETS": "etc.",
 "EL": "el",
 "SH*": "sh",
 "AUR/TKEU/TPHAEUR": "ordinary",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -870,7 +870,7 @@
 "KAFT": "cast",
 "AOET": "eat",
 "THORT": "authority",
-"ETS/TP-PL": "etc.",
+"*ETS": "etc.",
 "TPHRAOR": "floor",
 "EUL": "ill",
 "WAEUS": "ways",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -870,7 +870,7 @@
 "KAFT": "cast",
 "AOET": "eat",
 "THORT": "authority",
-"ETS/TP-PL": "etc.",
+"*ETS": "etc.",
 "TPHRAOR": "floor",
 "EUL": "ill",
 "WAEUS": "ways",


### PR DESCRIPTION
The stroke `ETS/TP-PL` outputs "et cetera." in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), so this proposal changes the entry to the new `*ETS` stroke for the abbreviated "etc."