### PR TITLE
Change dictionary entries for UK spelling of 'honour' to finger-spelling.

### DIFF
--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -844,7 +844,7 @@
 "KR-BL": "considerable",
 "KR*": "c",
 "PWROEBG": "broke",
-"HO*URPB": "honour",
+"H*/O*/TPH*/O*/*U/R*": "honour",
 "SEFPB": "seven",
 "PRAOEUFT": "private",
 "SEUT": "sit",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -844,7 +844,7 @@
 "KR-BL": "considerable",
 "KR*": "c",
 "PWROEBG": "broke",
-"HO*URPB": "honour",
+"H*/O*/TPH*/O*/*U/R*": "honour",
 "SEFPB": "seven",
 "PRAOEUFT": "private",
 "SEUT": "sit",


### PR DESCRIPTION
Follow up to #14. Somehow changing the remote branch name automatically closed the PR, and I couldn't seem to re-open it. Sorry about that!