### PR TITLE
O*/AE outputs as "O'", so change stroke for "o'" to O*/TK-LS/AE

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -257,7 +257,7 @@
 "WAOEUFS": "wives",
 "APB/AE": "an'",
 "KR*/TP-PL": "c.",
-"O*/AE": "o'",
+"O*/TK-LS/AE": "o'",
 "SR*/TP-PL": "v.",
 "KEUPBG/AES": "king's",
 "TKPWOD/AES": "god's",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -950,7 +950,7 @@
 "PEFGS": "possession",
 "PHREFPBT": "pleasant",
 "P-FRL": "perfectly",
-"O*/AE": "o'",
+"O*/TK-LS/AE": "o'",
 "PHOEURPL": "memory",
 "AOURBL": "usually",
 "TKPWRAEUF": "grave",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -950,7 +950,7 @@
 "PEFGS": "possession",
 "PHREFPBT": "pleasant",
 "P-FRL": "perfectly",
-"O*/AE": "o'",
+"O*/TK-LS/AE": "o'",
 "PHOEURPL": "memory",
 "AOURBL": "usually",
 "TKPWRAEUF": "grave",


### PR DESCRIPTION
In Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), `O*/AE` outputs as uppercase "O'", so change stroke for lowercase "o'" to the correct `OE/AE`.