### PR TITLE
Change the stroke for 'v.' to output lowercase instead of uppercase

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -245,7 +245,7 @@
 "APB/AE": "an'",
 "KR*/TP-PL": "c.",
 "O*/AE": "o'",
-"5R/TP-PL": "v.",
+"SR*/TP-PL": "v.",
 "KEUPBG/AES": "king's",
 "TKPWOD/AES": "god's",
 "WOPL/AES": "woman's",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -973,7 +973,7 @@
 "TUFP": "touch",
 "KWAL": "equal",
 "TP-RPB": "fortune",
-"5R/TP-PL": "v.",
+"SR*/TP-PL": "v.",
 "SHOR": "shore",
 "TKPHAEUPB": "domain",
 "TPHAEUPLD": "named",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -973,7 +973,7 @@
 "TUFP": "touch",
 "KWAL": "equal",
 "TP-RPB": "fortune",
-"5R/TP-PL": "v.",
+"SR*/TP-PL": "v.",
 "SHOR": "shore",
 "TKPHAEUPB": "domain",
 "TPHAEUPLD": "named",


### PR DESCRIPTION
In Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), `5R` outputs uppercase "V", so this PR proposes to change the stroke for "v." from uppercase `5R/TP-PL` to the finger-spelled lowercase `SR*/TP-PL`.