### PR TITLE
Change stroke for "James" from  SKWRAEUPLZ to SKWRAEUPLS

### DIFF
--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -884,7 +884,7 @@
 "SKWR*UL": "jul",
 "PROUBGS": "production",
 "KPHERBL": "commercial",
-"SKWRAEUPLZ": "James",
+"SKWRAEUPLS": "James",
 "WAET": "weight",
 "TOUPB": "town",
 "HART": "heart",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1040,7 +1040,7 @@
 "SPAOEUT": "spite",
 "SHOEPB": "shown",
 "TKREL": "directly",
-"SKWRAEUPLZ": "James",
+"SKWRAEUPLS": "James",
 "HA*RT": "Hart",
 "SAOERS": "serious",
 "HAT": "hat",


### PR DESCRIPTION
A bit of a subjective PR, but I'm proposing a change to the stroke Typey Type uses for "James" from `SKWRAEUPLZ` to `SKWRAEUPLS` for no other reason than reducing the reach needed for the right pinky finger. The accent of the word "James" can be either a soft 's' or hard 'z' sound, and my general thinking is "why reach for 'z' when 's' will do?".