### PR TITLE
Add EPB/TKPWAEUPBLGD condensed stroke for "engaged"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -115,6 +115,7 @@
 "UPB/STKAOEUD/-D": "undecided",
 "STKAOEUD/-D": "decided",
 "STKAOEUD/-D/HREU": "decidedly",
+"EPB/TKPWAEUPBLGD": "engaged",
 "EPB/TKPWAEUPBLG/-D": "engaged",
 "PHEUZ/TAOBG": "mistook",
 "TPAER/AES": "father's",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -5298,7 +5298,7 @@
 "PWAFP/HROR": "bachelor",
 "AT/TAOUD": "attitude",
 "KAPL/KORD/*ER/-S": "camcorders",
-"EPB/TKPWAEUBLG/-D": "engaged",
+"EPB/TKPWAEUBLGD": "engaged",
 "TPAULG": "falling",
 "PWAEUFBGS": "basics",
 "PHOPB/TRAL": "Montreal",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1104,7 +1104,7 @@
 "TKPWHROER": "glory",
 "TWEFL": "twelve",
 "SPAEUS": "space",
-"EPB/TKPWAEUBLG/-D": "engaged",
+"EPB/TKPWAEUBLGD": "engaged",
 "PAOERT": "Peter",
 "WAOEUPB": "wine",
 "OERD": "ordinary",


### PR DESCRIPTION
Add `EPB/TKPWAEUPBLGD` condensed stroke for "engaged" in `condensed-strokes.json`, and have the Typey Type dictionaries use it. The only real reason for this proposal is that it's one stroke less than the current `EPB/TKPWAEUBLG/-D` stroke, and doesn't, in my opinion, make the stroke more difficult or convoluted to execute.