### PR TITLE
Fix typo in stroke for "evidence"

### DIFF
--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -1304,7 +1304,7 @@
 "TH-FR": "therefore",
 "A*S": "ass",
 "SAO*EPL": "simply",
-"EFD": "evidence",
+"*EFD": "evidence",
 "STAEUGS": "station",
 "KREUGS": "Christian",
 "ROUPBD": "round",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1175,7 +1175,7 @@
 "POURS": "powers",
 "POS/ES/-D": "possessed",
 "THROEPB": "thrown",
-"EFD": "evidence",
+"*EFD": "evidence",
 "STKAPBT": "distant",
 "PHAOEUBG/*L": "Michael",
 "PROG": "progress",


### PR DESCRIPTION
Since there is no `EFD` stroke in the current `dict.json`, or the Plover dictionaries, for "evidence", I'm assuming that its use in the `top-10000-*.json` dictionaries is a typo. So, this PR fixes it to its correct `*EFD` stroke.