### PR TITLE
Add "SELT": "settle" and suffixes

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1,4 +1,7 @@
 {
+"SELTD": "settled",
+"SELTG": "settling",
+"SELTS": "settles",
 "A/PAEUS": "apace",
 "PHAOPB/SHAO*EUPB": "moonshine",
 "TPERGT/-FL/-PBS": "forgetfulness",

--- a/dictionaries/nouns.json
+++ b/dictionaries/nouns.json
@@ -1,4 +1,5 @@
 {
+"SELT": "settle",
 "HOEURL": "historical",
 "TPHA*EUGS/-S": "nations",
 "TPHA*EUGSZ": "nations",


### PR DESCRIPTION
"SELTD": "settled", "SELTG": "settling", and "SELTS": "settles", can all
be written without explicit entries using Plover’s orthography rules. We
add explicit entries to condensed strokes to improve Typey Type
suggestions and improve brief look ups.

Fixes #28