### PR TITLE
Change "seas" from SAEZ to SAES

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -82536,7 +82536,7 @@
 "SAERPLT": "argument is",
 "SAERS": "Sears",
 "SAERZ": "Sears",
-"SAES": "satisfies",
+"SAES": "seas",
 "SAET": "Saturday",
 "SAET/AOEPBG/POEFT": "Saturday Evening Post",
 "SAET/REU": "satisfactory",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -9730,7 +9730,7 @@
 "SRERBL": "verbal",
 "PWHR*EUPBG": "blink",
 "PREPBLT": "presently",
-"SAEZ": "seas",
+"SAES": "seas",
 "KAR/HROE": "Carlo",
 "WORBG/TPHROE": "workflow",
 "PHEUFT/RUS": "mysterious",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3242,7 +3242,7 @@
 "EUPL/PHRAOEUD": "implied",
 "PHA/REU/KWRA": "Maria",
 "STAOUPD": "stupid",
-"SAEZ": "seas",
+"SAES": "seas",
 "SPAPB/KWRARDZ": "Spaniards",
 "TKPWRAEUPB": "grain",
 "SKWROEUPLT": "enjoyment",


### PR DESCRIPTION
This PR proposes to change the stroke for "seas" from `SAEZ`, to its easier-to-stroke counterpart `SAES` for that reason only, not because of any correctness issues with `SAEZ`.

`dict.json` already has an entry for `SAES` as "satisfies", but as of Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), it would seem that this is now incorrect, and hence there is a separate commit to change it to the now-correct "seas".

If it's not worth changing the `"SAEZ": "seas"` entry in Typey Type dictionaries, I'm happy to take that commit out of this PR and just leave the fix for `"SAES": "satisfies"`.