### PR TITLE
Remove WAED stroke for "wade"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -136592,7 +136592,6 @@
 "WAEBG/-PBS": "weakness",
 "WAEBG/HREUPBG": "weakling",
 "WAEBGDZ": "wait a second{,}please",
-"WAED": "wade",
 "WAEF": "weave",
 "WAEFD": "wasted",
 "WAEFGT": "wasting",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8367,7 +8367,7 @@
 "TKEBG/RAEUGS": "decoration",
 "HER/WEUFPL": "heroism",
 "TO*E": "toe",
-"WAED": "wade",
+"WAEUD": "wade",
 "AP/PARL": "apparel",
 "HAEUZ/EL": "hazel",
 "TPHABLT": "inability",


### PR DESCRIPTION
This PR proposes to remove the `WAED` stroke for "wade", as it would seem to have been removed from Plover as of release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), and updates the Typey-Type dictionary to use `WAEUD` for "wade" instead.