### PR TITLE
Fix entry for KOEF stroke from "cove" to "coffee"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -37316,7 +37316,7 @@
 "KOED/TPEU": "codify",
 "KOED/TPEU/KAEUGS": "codification",
 "KOEDZ": "codes",
-"KOEF": "cove",
+"KOEF": "coffee",
 "KOEFG": "coving",
 "KOEFLT/A*L": "coastal",
 "KOEFP": "coach",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -9058,7 +9058,7 @@
 "PWRAOEFS": "briefs",
 "SEURGS": "signatures",
 "TKEUF/-S": "diffs",
-"KOEF": "cove",
+"KO*EF": "cove",
 "PHUPL/PWAOEU": "Mumbai",
 "OEZ/OEPB": "ozone",
 "TKEUS/PHREUPS": "disciplines",


### PR DESCRIPTION
Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) would seem to have changed the `KOEF` stroke meaning from "cove" to "coffee", so this PR:

- Fixes the `KOEF` entry
- Reflects this change in the Typey-Type dictionary so that "cove" now uses the `KO*EF` stroke