### PR TITLE
Change stroke for "guys" from TKPWEUS to TKPWAOEUS

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -468,5 +468,6 @@
 "UFPB": "UPB un^ misstroke",
 "UB": "UPB un^ misstroke",
 "UPBDZ": "UPBD under^ misstroke",
+"TKPWAOUZ": "guys",
 "WUZ/WUZ": "{#}"
 }

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -118051,7 +118051,6 @@
 "TKPWEURLS/KOEGD/KHRUB": "Girls Coding Club",
 "TKPWEURT": "girt",
 "TKPWEURTD/*ER": "girder",
-"TKPWEUS": "guys",
 "TKPWEUS/HREUPB": "glycerin",
 "TKPWEUS/TKPWUFT": "disgust",
 "TKPWEUT/A*R": "guitar",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -118051,6 +118051,7 @@
 "TKPWEURLS/KOEGD/KHRUB": "Girls Coding Club",
 "TKPWEURT": "girt",
 "TKPWEURTD/*ER": "girder",
+"TKPWEUS": "GIS",
 "TKPWEUS/HREUPB": "glycerin",
 "TKPWEUS/TKPWUFT": "disgust",
 "TKPWEUT/A*R": "guitar",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -117441,7 +117441,6 @@
 "TKPWAOUT/KWRER/EZ": "Gutierrez",
 "TKPWAOUT/PHA/HRA": "Guatemala",
 "TKPWAOUT/PHAL/A*PB": "Guatemalan",
-"TKPWAOUZ": "guys",
 "TKPWAOUZ/ES/THAOE/SHA": "geusesthesia",
 "TKPWAP": "gap",
 "TKPWAPB": "began",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -2147,7 +2147,7 @@
 "KOFRD": "covered",
 "ROEUFR": "recovery",
 "SKWROE": "Joe",
-"TKPWEUS": "guys",
+"TKPWAOEUS": "guys",
 "EUPB/TKPWRAEUTD": "integrated",
 "TKPWRAEUGS": "configuration",
 "KOBG": "cock",


### PR DESCRIPTION
As of Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), the stroke `TKPWEUS` no longer resolves to "guys", but to "GIS", so this PR:

- Changes the entry for the `TKPWEUS` stroke from "guys" to "GIS"
- Changes the Typey-Type dictionaries to use the `TKPWAOEUS` stroke for "guys" (there are other strokes that could be used here, so this is a subjective proposal on my part; it just felt like the easiest and most logical stroke to me)