### PR TITLE
Change stroke for "mo" entry to its fingerspelling

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -59000,7 +59000,7 @@
 "PHEZ/SKWRO": "mezzo",
 "PHEZ/TPHAOEPB": "mezzanine",
 "PHEZ/TPHAOEUPB": "mezzanine",
-"PHO": "mo",
+"PH*/O*": "mo",
 "PHO*": "Missouri",
 "PHO*/PHO*": "Missouri",
 "PHO*B/KHROEPBL": "monoclonal",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -2187,7 +2187,7 @@
 "PHOET/ROE/HRA": "Motorola",
 "S*EPS": "acceptance",
 "STRAPLGS": "strategies",
-"PHO": "mo",
+"PH*/O*": "mo",
 "SAOEPL": "seem",
 "A/TPAEURS": "affairs",
 "TUFP": "touch",


### PR DESCRIPTION
As of Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), the stroke `PHO` resolves to "no", which means that there is now not a specific stroke available for the "mo" entry. Therefore, the PR proposes a change to its fingerspelling.