### PR TITLE
Change stroke for falls from TPAULZ to TPAULS

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -124326,7 +124326,7 @@
 "TPAULG": "falling",
 "TPAULG/SKWRO*UT": "falling-out",
 "TPAULGS": "falx",
-"TPAULS": "false",
+"TPAULS": "falls",
 "TPAULS/-PBS": "falseness",
 "TPAULS/HAOD": "falsehood",
 "TPAULS/HAODZ": "falsehoods",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -2399,7 +2399,7 @@
 "PAFD": "passed",
 "SPHRAOEUD": "supplied",
 "AOEUD/TPAOEUD": "identified",
-"TPAULZ": "falls",
+"TPAULS": "falls",
 "P*EUBG": "pic",
 "SOUL": "soul",
 "AEUDZ": "aids",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2519,7 +2519,7 @@
 "K-FRPL/-D": "confirmed",
 "TKAOE/SEPBD/-D": "descended",
 "RURB": "rush",
-"TPAULZ": "falls",
+"TPAULS": "falls",
 "TKOEUPB": "deny",
 "KHRAEUTD": "calculated",
 "KRERBG": "correct",


### PR DESCRIPTION
As of Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), the stroke `TPAULS` resolves to "falls", rather than "false". This means that "falls" can now be stroked a bit easier using `TPAULS`, rather than stretching for the Z in `TPAULZ`. Therefore, this PR:

- Changes the entry for the `TPAULS` stroke from "false" to "falls"
- Changes Typey-Type dictionaries to reference the new subjectively-easier-to-stroke `TPAULS` for "falls"