### PR TITLE
Use easier-to-stroke PHARS for 'Mars', rather than PHARZ

### DIFF
--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -5143,7 +5143,7 @@
 "PAEPBG": "passenger",
 "SRAOEPB": "convenient",
 "TKEPB/TPHEUS": "Dennis",
-"PHARZ": "Mars",
+"PHARS": "Mars",
 "TPRAPB/EUS": "Francis",
 "T*F/-S": "TVs",
 "SAOEUZ/-D": "sized",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6329,7 +6329,7 @@
 "PHRUPBG": "plunge",
 "PHO*R": "moor",
 "PEUPB": "pin",
-"PHARZ": "mars",
+"PHARS": "Mars",
 "SOERBT": "associate",
 "HAOERS": "here's",
 "O/WEPB": "Owen",


### PR DESCRIPTION
All the strokes for "Mars" are currently in the dictionaries, but this PR just proposes that the stroke Typey-Type uses is changed from `PHARZ` to `PHARS` to forgo reaching for the `Z` when an `S` will do.