### PR TITLE
Fix capitalisation of some human names in Typey-Type dictionaries

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -130316,7 +130316,7 @@
 "TPO*R/TRAPB": "FORTRAN",
 "TPO*RBGS": "New York City",
 "TPO*RBGT": "forgot",
-"TPO*RD": "Ford",
+"TPO*RD": "{^ford}",
 "TPO*RDZ": "Fords",
 "TPO*RGD": "forgotten",
 "TPO*RGT": "forgot",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -5922,7 +5922,7 @@
 "SPEBG/TABG/HRAR": "spectacular",
 "KAOR/TPHAEUGS": "coordination",
 "KEBG/TOR": "connector",
-"PWRAD": "brad",
+"PWRAD": "Brad",
 "KOPL/PWOE": "combo",
 "SOEURPBS": "seniors",
 "WORLDZ": "worlds",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -8923,7 +8923,7 @@
 "PH-S/AO*E": "msie",
 "R-PBG": "reasoning",
 "W*/TPH*": "wn",
-"HREUZ": "liz",
+"HREUZ": "Liz",
 "REPBD/TKERD": "rendered",
 "P*EUG": "picking",
 "KHAEURBL": "charitable",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -4256,7 +4256,7 @@
 "KAF/AEU": "cafe",
 "SRAL/TAOEUPB": "Valentine",
 "HEUL/TOPB": "Hilton",
-"KEPB": "ken",
+"KEPB": "Ken",
 "PRAO*EPBS": "proteins",
 "HOR/ROR": "horror",
 "S*/*U": "su",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -8685,7 +8685,7 @@
 "PAR/SEL": "parcel",
 "RE/TPAOEUPBD": "refined",
 "TP*/TK*": "fd",
-"PWO": "bo",
+"PWO": "Bo",
 "TPEUF/TAOEPB": "fifteen",
 "WAOEU/SPRED": "widespread",
 "EUPBS/TKES": "incidence",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -9603,7 +9603,7 @@
 "TPORBS": "Forbes",
 "PHA*E": "mae",
 "PHOL/TKOE/SRA": "Moldova",
-"PHEL": "mel",
+"PHEL": "Mel",
 "TKE/SEPBD/-G": "descending",
 "PABGS/EUL": "paxil",
 "SPAOEUPB": "spine",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -8275,7 +8275,7 @@
 "R*/P*": "rp",
 "PWEUPBD": "bind",
 "TRAPBGS/TKPWEUFG": "thanksgiving",
-"RAPBD": "rand",
+"RAPBD": "Rand",
 "HOP/KEUPBZ": "Hopkins",
 "URGT": "urgent",
 "TKPWARPBTS": "guarantees",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8705,7 +8705,7 @@
 "SHRAOEUS": "slice",
 "RAEPBS": "renaissance",
 "APB/SKWRE/HROE": "Angelo",
-"PHEG": "meg",
+"PHEG": "Meg",
 "PHURD/RUS": "murderous",
 "SR*EPBT": "serenity",
 "PERP/RAEUGS": "perspiration",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8300,7 +8300,7 @@
 "RAOT/-D": "rooted",
 "OUT/PWURS/-T": "outburst",
 "TPORT/TAOUD": "fortitude",
-"TURBG": "turk",
+"TURBG": "Turk",
 "TKE/SROUR": "devour",
 "PHAL/EUG/TPHAPBT": "malignant",
 "A/KORD/-D": "accorded",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3060,7 +3060,7 @@
 "TAER": "tear",
 "TKAPB": "Dan",
 "RE/SEUFT": "resist",
-"PWOB": "Bob",
+"PWO*B": "Bob",
 "TK*EPTS": "depths",
 "PHAEUD/*EPB": "maiden",
 "TKERPL": "determine",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6617,7 +6617,7 @@
 "TPEURPL/-PBS": "firmness",
 "KO*BG": "comic",
 "PWRAOED/-G": "breeding",
-"KEPB": "ken",
+"KEPB": "Ken",
 "KWEG": "questioning",
 "TPARBGT": "factor",
 "PHOPB/AOUPLTS": "monuments",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4413,7 +4413,7 @@
 "TPOUPB/TAEUPB": "fountain",
 "STAEPBD": "sustained",
 "PROET": "appropriate",
-"TPORD": "Ford",
+"TPO*ERD": "Ford",
 "KHRA/RA": "Clara",
 "S*EUFD": "assisted",
 "HRAO*US": "Lewis",


### PR DESCRIPTION
This PR does the following related to human names:

- fixes the discrepancy for `PWRAD`, `PWO`, `HREUZ`, and `PHEL` entries between `dict.json` (where they are correct) and Typey-Type dictionaries (where they are incorrect).
- fixes the stroke entry for capitalised "Bob" from `PWOB` to `PWO*B` (there is an entry in `top-10000-english-words.json` for `"PWOB": "bob"`, and I'm currently assuming that this is for the verb "to bob", rather than the name "Bob")
- changes Typey-Type dictionary entry for capital "Ford", and changes the `TPO*RD` entry to mean `{^ford}` rather than "Ford", as per changes in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)