### PR TITLE
Change stroke for "breadth" from PWRET to PWR*ED

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -73126,7 +73126,6 @@
 "PWRES/HREUPB": "Breslin",
 "PWRES/HROE": "Breslow",
 "PWRES/PWEU/TAOERPB": "Presbyterian",
-"PWRET": "breadth",
 "PWRET/AOES/TO*PB/EL/HREUS": "Brett Easton Ellis",
 "PWRET/O*PB": "Breton",
 "PWRET/PWRET": "Brett",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4668,7 +4668,7 @@
 "HAOEUTS": "heights",
 "A/PROFL": "approval",
 "TKPWAFPD": "gasped",
-"PWRET": "breadth",
+"PWR*ED": "breadth",
 "WRAU": "withdraw",
 "TAOUPB": "tune",
 "KPAGS": "compassion",


### PR DESCRIPTION
Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) would seem to have removed stroke `PWRET` for "breadth", so this PR:

- removes `PWRET` from `dict.json`
- changes the Typey-Type stroke for "breadth" to `PWR*ED`