### PR TITLE
Use PEUBGS over PEUBGZ for "picks"

### DIFF
--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -4224,7 +4224,7 @@
 "PHAEURBG": "maker",
 "KRABG": "crack",
 "PREUPB": "principle",
-"PEUBGZ": "picks",
+"PEUBGS": "picks",
 "SRAEU/KAEUGS/-S": "vacations",
 "TKPWAPBG": "gang",
 "SPHEFT": "semester",


### PR DESCRIPTION
 This PR proposes that for the word "picks", Typey-Type dictionaries should use easier-to-stroke `PEUBGS` over the current `PEUBGZ` stroke.