### PR TITLE
Change stroke used for "kings" in Typey-Type dictionaries

### DIFF
--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -4586,7 +4586,7 @@
 "RAEUGDZ": "radiation",
 "TKAOEU/REU": "diary",
 "SAOERLS": "seriously",
-"KEUPBGZ": "kings",
+"KEUPBGS": "kings",
 "SHAOGT": "shooting",
 "KEPBT": "Kent",
 "ADZ": "adds",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1446,7 +1446,7 @@
 "UL": "you'll",
 "SKWROEUPBD": "joined",
 "TAOULT": "actually",
-"KEUPBGZ": "kings",
+"KEUPBGS": "kings",
 "S*/TK*": "SD",
 "POEFTD": "posted",
 "PROEFP": "approach",


### PR DESCRIPTION
This PR proposes to change the stroke used for "kings" in Typey-Type dictionaries from `KEUPBGZ` to the easier-to-stroke `KEUPBGS`.