### PR TITLE
Change entry for HAPBGD stroke from "hanged" to "handing"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -22488,7 +22488,7 @@
 "HAPBG/SKWROUT": "hangout",
 "HAPBG/TKPWHRAOEUD/*ER": "hang glider",
 "HAPBG/TPHAEUL": "hangnail",
-"HAPBGD": "hanged",
+"HAPBGD": "handing",
 "HAPBGS": "hangs",
 "HAPBGT": "hangout",
 "HAPBL": "handle",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5198,7 +5198,7 @@
 "SHOBGD": "shocked",
 "ES/KORT": "escort",
 "TPERGT/-G": "forgetting",
-"HAPBGD": "hanged",
+"HAPBG/-D": "hanged",
 "HATS": "hats",
 "PH*EURT": "mirth",
 "TPH-BL": "uncomfortable",


### PR DESCRIPTION
Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) would seem to have changed the entry for the `HAPBGD` stroke from "hanged" to "handing".

Therefore, this PR proposes to:

- Change the mapping for `HAPBGD` from "hanged" to "handing"
- Change Typey-Type dictionaries to use multi-stroke `HAPBG/-D` for "hanged", since it is now the only stroke available for that word