### PR TITLE
Fix capitalisation on 'IDs'

### DIFF
--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -9963,7 +9963,7 @@
 "SAEUFR": "safer",
 "EUPB/SERGS": "insertion",
 "STRAOUPLT/AEUGS": "instrumentation",
-"EUFPLT/TK-FPLT/-S": "ids",
+"EUFPLT/TK-FPLT/-S": "IDs",
 "HAOU/TKPWOE": "Hugo",
 "WAG/TPHER": "Wagner",
 "KAUPB/STRAEUPBT": "constraint",


### PR DESCRIPTION
The `dictionaries/dict.json:16557` entry for "IDs" (`EUFPLT/TK-FPLT/-S": "IDs"`) is correct, but

https://github.com/didoesdigital/steno-dictionaries/blob/ef5681c357435ecfcf8da70121974b861d7eb5aa/dictionaries/top-10000-english-words.json#L9966

does not have the correct capitalisation, so this PR fixes that.