### PR TITLE
Change stroke for "obj" to its fingerspelling

### DIFF
--- a/dictionaries/code.json
+++ b/dictionaries/code.json
@@ -25,7 +25,7 @@
 "PH-S/AO*E": "msie",
 "TPAOEUR/WAOEUR": "firewire",
 "KWRUR": "uri",
-"O*PBLG": "obj",
+"O*/PW*/SKWR*": "obj",
 "STR*EUPBG": "str",
 "EPBD/*F": "endif",
 "PR*EPBLG/STR*EUPBG": "msgstr",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -8369,7 +8369,7 @@
 "SRAEUBG/SEU/-S": "vacancies",
 "KWEUSZ": "quizzes",
 "PARPLT/REU": "parliamentary",
-"O*PBLG": "obj",
+"O*/PW*/SKWR*": "obj",
 "PREFBGS": "prefix",
 "HRAOU/KHA": "Lucia",
 "SA/SRA/TPHA": "savannah",


### PR DESCRIPTION
The dictionaries currently have entries for "obj" in the following places:

https://github.com/didoesdigital/steno-dictionaries/blob/f98e522fd3637a7fe8b9f3cdf79544b15b25ff1c/dictionaries/code.json#L28

https://github.com/didoesdigital/steno-dictionaries/blob/ef5681c357435ecfcf8da70121974b861d7eb5aa/dictionaries/top-10000-english-words.json#L8372

However, Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) does not have a stroke entry for "obj", and the stroke `O*PBLG ` outputs as-is, so this PR proposes to change the stroke for "obj" to its finger-spelling (`O*/PW*/SKWR*`).