### PR TITLE
Change entry for 'quitted' to its fingerspelling.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5262,7 +5262,7 @@
 "PERPGS": "perception",
 "PWUF/HROE": "buffalo",
 "SAOEUR": "sire",
-"KWEUT/-D": "quitted",
+"KW*/*U/*EU/T*/T*/*E/TK*": "quitted",
 "KAOES": "keys",
 "SREL": "develop",
 "TPUBGS": "function",


### PR DESCRIPTION
Changes the `"quitted"` entry stroke of `"KWEUT/-D"`, which currently outputs "quited" in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), with the fingerspelling of the word "quitted".

Closes #61 