### PR TITLE
Change 'notre' entries to 'Notre Dame'.

### DIFF
--- a/dictionaries/nouns.json
+++ b/dictionaries/nouns.json
@@ -220,7 +220,7 @@
 "KRO*L": "ctrl",
 "HRAOEUT/TK-LS/PWOBGS": "lightbox",
 "PHO*EUD/W*EUBG": "mediawiki",
-"TPHOET/RE": "notre",
+"TPHORT/TKAEUPL": "Notre Dame",
 "EUPB/SP*EF": "inexpensive",
 "TAOL/TK-LS/KEUT": "toolkit",
 "PHRAEU/TK-LS/PWABG": "playback",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -9840,7 +9840,7 @@
 "*EF/TPHES/EPBS": "evanescence",
 "SUBLT": "subtle",
 "KWORD/TPHAEUT/-D": "coordinated",
-"TPHOET/RE": "notre",
+"TPHORT/TKAEUPL": "Notre Dame",
 "SHEUPLTS": "shipments",
 "PHAL/TKAO*EUFZ": "Maldives",
 "STRAOEUPS": "stripes",


### PR DESCRIPTION
Due to Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) not having an entry for the word "notre", and given that "notre" was _probably_ only included in [Google’s Trillion Word Corpus via Josh Kaufman's typing word list](https://didoesdigital.com/typey-type/support#credits) due to it being a part of the landmark/place name "Notre Dame", this PR proposes to give the "notre" entries their full context by changing them all to "Notre Dame".

Closes #58 