### PR TITLE
Fix mis-strokes for "fluid" and "lenses"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -151,6 +151,7 @@
 "TKRAO/PEU": "droopy",
 "HRES/EPB/THAO*US/KWRAFT/EUBG": "less enthusiastic",
 "HRES/EPB/THAOUS": "less enthuse",
+"THRAOUD": "fluid",
 "THU/ST-BG": "enthusiastic",
 "THUFPL": "enthusiasm",
 "THAOUS/AFPL": "enthusiasm",

--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -545,6 +545,7 @@
 "W*ED": "Wednesday",
 "KPAR/SOPBS": "comparisons",
 "AL/TPA/PWET/K-L": "alphabetical",
+"HREBSZ": "lenses",
 "HREPBLG/-BL/TEU": "legibility",
 "KOUFRPBT": "KOURPBT counter^ misstroke",
 "PHRO*EUPB": "PHAO*UPB immuno^ misstroke",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -109665,7 +109665,6 @@
 "THRAOUBG": "therapeutic",
 "THRAOUBG/HREU": " therapeutically",
 "THRAOUBGS": "therapeutics",
-"THRAOUD": "fluid",
 "THRAOUL": "actually",
 "THRAOUL/AOEUZ/-D": "actualized",
 "THRAOULT": "actually",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -27454,7 +27454,6 @@
 "HREBGT/WAEL": "intellectually",
 "HREBLG/TAOUR": "lecture",
 "HREBS/KWRAPB": "lesbian",
-"HREBSZ": "lenses",
 "HRED": "led",
 "HRED/S*EP/HREUPB": "Led Zeppelin",
 "HREF": "leave",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -5305,7 +5305,7 @@
 "KARPT": "carpet",
 "R*/SR*": "rv",
 "STR*UBGT": "struct",
-"HREBSZ": "lenses",
+"HREPBSZ": "lenses",
 "PWAOEUPB/REU": "binary",
 "SKWR*EPBGS": "genetics",
 "A/TEPBD/-D": "attended",

--- a/dictionaries/top-10000-english-words.json
+++ b/dictionaries/top-10000-english-words.json
@@ -5084,7 +5084,7 @@
 "PROEPL/-G": "promoting",
 "S*ERBGS": "sectors",
 "SAPL/WEL": "Samuel",
-"THRAOUD": "fluid",
+"TPHRAOUD": "fluid",
 "TKPWROUPBDZ": "grounds",
 "TPEUTS": "fits",
 "KEUBG": "kick",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6772,7 +6772,7 @@
 "SREUPB/SEPBT": "Vincent",
 "SHEFL": "shelf",
 "TPAPB": "fan",
-"THRAOUD": "fluid",
+"TPHRAOUD": "fluid",
 "PWRAOEULT": "brightly",
 "TKAPL/SEL": "damsel",
 "TKPWAEUB/REL": "Gabriel",


### PR DESCRIPTION
This PR fixes the (still-valid-in-Plover) mis-strokes brought up in #41. Specifically:

- Change stroke for `"fluid"` from `"THRAOUD"` to `"TPHRAOUD"`
- Change stroke for `"lenses"` from `"HREBSZ"` to `"HREPBSZ"`

(The stroke for `"fault"` had already been fixed, so no changes needed).