### PR TITLE
Change Typey-Type stroke for 'slept' from SHREPD to SHREPT

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2044,7 +2044,7 @@
 "TRAOEUFPL": "triumph",
 "O*RPBLG": "origin",
 "SKWROE/SEF": "Joseph",
-"SHREPD": "slept",
+"SHREPT": "slept",
 "E/TERPBL": "eternal",
 "THAOEUPB": "thine",
 "AUPBS": "audience",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for the word "slept":

```json
"SHREPD": "slept",
"SHREPT": "slept",
```

Both of these strokes are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33P), but the stroke that appears in Typey-Type is:

https://github.com/didoesdigital/steno-dictionaries/blob/5ad75a255ea296068cacd89b05c30de93d5375c0/dictionaries/top-10000-project-gutenberg-words.json#L2047

I would posit that:

- `SHREPT` sounds like a _more_ correct stroke for "slept"
- If you don't need to reach for the steno "D" key for a correct stroke, then you shouldn't be made to

Therefore, this PR proposes to change the entry in `top-10000-project-gutenberg-words.json` for "slept" from `SHREPD` to `SHREPT`.