### PR TITLE
Remove incorrect condensed stroke of AO*EUD for 'eyed'

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -28,7 +28,6 @@
 "P*/*E": "pe",
 "*U/TPH*": "un",
 "KWR*/*U": "yu",
-"AO*EUD": "eyed",
 "HAOU/-D": "hued",
 "S*/T*": "st",
 "T*P/*U": "Tu",


### PR DESCRIPTION
In Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), the stroke `AO*EUD` is not present for the word "eyed".

All entries for "eyed" in other dictionaries are for the correct `KWRAOEUD` stroke, so I'm assuming that the condensed stroke was once correct, but now it is not, so this PR seeks to remove it so it does not appear in Typey-Type.

This does bring up a separate issue that about the current output for the stroke `AO*EUD`. `AO*EUD` outputs "ID" in all capitals, however, in the dictionaries, we have:

```
top-10000-project-gutenberg-words.json: "EUD": "ID",
dict.json: "AO*EUD": "ID",
```

The `EUD` stroke for "ID" is now incorrect, as it outputs "id" in lowercase. Happy to handle the changes needed to fix these two entries here, or a separate PR. Specifically:

- Either change the `top-10000-project-gutenberg-words.json` entry of `"EUD": "ID"` to `"EUD": "id"` or `"AO*EUD": "ID"`, depending on the intention