### PR TITLE
Change output of EUD stroke from 'ID' to correct 'id'

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3165,7 +3165,7 @@
 "STAO*UDZ": "studies",
 "PWAL": "balance",
 "SPWROURS": "intercourse",
-"EUD": "ID",
+"EUD": "id",
 "TPORPLG": "forming",
 "SHRERPBD": "slender",
 "KOEFP": "coach",


### PR DESCRIPTION
Following up from #79, this PR corrects the output for the `EUD` from uppercase "ID" to lowercase "id".