### PR TITLE
Fix stroke for "clutch"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -560,6 +560,7 @@
 "HROED/-G": "loading",
 "HROED/ER": "loader",
 "HROEDZ": "loads",
+"HRUFP": "clutch",
 "TKPWAOEL": "goal",
 "TEF": "TEFT test misstroke",
 "SRA*EUR": "SRAER vary brief misstroke",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -29218,7 +29218,6 @@
 "HRUF": "love",
 "HRUFG": "loving",
 "HRUFL": "lovely",
-"HRUFP": "clutch",
 "HRUFR": "lover",
 "HRUFRP": "lump",
 "HRUFRP/EBGT/PH*EU": "lumpectomy",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9939,7 +9939,7 @@
 "HRAOEUPBG": "lining",
 "KHREFR/-PBS": "cleverness",
 "A/SET/EUBG": "ascetic",
-"HRUFP": "clutch",
+"KHRUFP": "clutch",
 "KREURB/TPHA": "Krishna",
 "EPL/PWARBG": "embark",
 "KWOE/TAEUGS/-S": "quotations",


### PR DESCRIPTION
Fixes #81 by:

- moving `HRUFP` mis-stroke for "clutch" into `bad-habits.json`
- updating `top-10000-project-gutenberg-words.json` with correct stroke `KHRUFP` for "clutch"