### PR TITLE
Move `EPBG` mis-stroke for "edge" into `bad-habits.json`.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -455,6 +455,7 @@
 "PHOUPBT/TPHOUS": "mountainous",
 "PHOUPBT/TPHUS": "mountainous",
 "EPB/TKPWAEUPBL": "engage",
+"EPBG": "edge",
 "PHERPLT": "ferment",
 "A/PARD": "apart",
 "KWRAOEBG": "Greek",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -15535,7 +15535,6 @@
 "EPBDZ": "ends",
 "EPBDZ/-LS": "endless",
 "EPBDZ/OS/KOEP/KWREU": "endoscopy",
-"EPBG": "edge",
 "EPBG/*L": "Engel",
 "EPBG/-PB": "engine",
 "EPBG/-PBS": "engines",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1490,7 +1490,7 @@
 "TPAEU/SROUR": "favour",
 "HAOEUT": "height",
 "SAOEUZ": "size",
-"EPBG": "edge",
+"EPBLG": "edge",
 "SUBTS": "subjects",
 "TAFBG": "task",
 "TPOLS": "follows",


### PR DESCRIPTION
Fixes #83.