### PR TITLE
Mark stroke PREGS for 'profession' as a mis-stroke

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -64843,7 +64843,6 @@
 "PREG/TPHAPBS/SEU": "pregnancy",
 "PREG/TPHAPBT": "pregnant",
 "PREG/TPHEPB/HROEPB": "pregnenolone",
-"PREGS": "profession",
 "PREGS/-D": "presented",
 "PREGT": "pregnant",
 "PREGT/SEU": "pregnancy",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2617,7 +2617,7 @@
 "KHRAEUPLS": "claims",
 "P*/P*/TP-PL": "pp.",
 "PHERT": "merit",
-"PREGS": "profession",
+"PREFGS": "profession",
 "HRAFRP": "lamp",
 "EUPBT/SRAOU": "interview",
 "TERT": "territory",


### PR DESCRIPTION
In Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), there is no entry for the stroke `PREGS` to mean "profession". Therefore, this PR aims to:

- Mark stroke `PREGS` for 'profession' as a mis-stroke in the dictionaries
- Change the Typey-Type stroke for it to the correct `PREFGS`