### PR TITLE
Change KAPLT stroke for "capital" to KPAL

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -555,6 +555,7 @@
 "TWUPBT": "it wasn't",
 "WUPBT": "wasn't",
 "KAPBT": "can't",
+"KAPLT": "capital",
 "T*EUS": "'tis",
 "AOEUPBLD": "and I'm",
 "TKUZ": "does",

--- a/dictionaries/briefs.json
+++ b/dictionaries/briefs.json
@@ -60,7 +60,6 @@
 "TPAEF": "fave",
 "TPAEF/-S": "faves",
 "TPAEUF": "fair enough",
-"KAPLT": "capital",
 "TPOUR/TPO*UR": "4",
 "TWO/TWO*": "2",
 "HO*URPB": "honour",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -39991,6 +39991,7 @@
 "KPAFT/TEU": "capacity",
 "KPAGS": "compassion",
 "KPAGS/TPHAT": "compassionate",
+"KPAL": "capital",
 "KPAL/TAEUGS": "exaltation",
 "KPALT": "exalt",
 "KPAO*EPL": "extreme",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1309,7 +1309,7 @@
 "SPEURTS": "spirits",
 "TPEURB": "fish",
 "TUPBG": "tongue",
-"KAPLT": "capital",
+"KPAL": "capital",
 "APBG/REU": "angry",
 "TKPWROEG": "growing",
 "SEFRBD": "served",


### PR DESCRIPTION
In the current `briefs.json` and `top-10000-project-gutenberg-words.json` dictionaries, there is the following single-stroke entry for the word "capital":

https://github.com/didoesdigital/steno-dictionaries/blob/c057ce8e7a1a43e0593f627eb9b43f0d09f79d85/dictionaries/briefs.json#L63

https://github.com/didoesdigital/steno-dictionaries/blob/c057ce8e7a1a43e0593f627eb9b43f0d09f79d85/dictionaries/top-10000-project-gutenberg-words.json#L1312

However, it would seem that `KAPLT` is no longer a valid stroke for "capital" in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33). It would seem that the stroke has changed to `KPAL`, which is not currently in any of the dictionaries. Therefore, this PR seeks to:

- Remove `KAPLT` from `briefs.json`
- Add  `KAPLT` to `bad-habits.json`
- Add `"KPAL": "capital"` to `dict.json`
- Change the "capital"  entry in `top-10000-project-gutenberg-words.json` to `KPAL`