### PR TITLE
Change incorrect 'patiently' single-stroke entry to correct two-stroke entry

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5416,7 +5416,7 @@
 "STAOURD": "steward",
 "TPAPB/T-FBG": "fantastic",
 "EFGS": "evolution",
-"PAEURBLT": "patiently",
+"PAEURBT/HREU": "patiently",
 "RE/SRES": "reverse",
 "SOEUF": "survey",
 "TKUG": "dug",


### PR DESCRIPTION
The two-stroke entry for "patiently" in `dict.json` is correct, but according to Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), there is no single-stroke entry for "patiently" (the only entry for "patiently" is `PAEURBT/HREU`).

The `top-10000-project-gutenberg-words.json` dictionary is the only place the incorrect entry appears, and so this PR seeks to just change that two the correct two-stroke entry.