### PR TITLE
Change stroke for "independently"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -114,6 +114,7 @@
 "TRAELS": "paralysis",
 "SEPL/PHRER": "simpler",
 "PAEUB": "maybe",
+"PAEPBLT": "independently",
 "KAOET": "Keith",
 "TPHAER": "{^ary}",
 "HREUPBS": "{^liness}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -49027,7 +49027,7 @@
 "PAEPBGS": "passengers",
 "PAEPBS": "panes",
 "PAEPBT": "independent",
-"PAEPBLT": "independently",
+"P*EPBLT": "independently",
 "PAEPBT/HREU": "independently",
 "PAER": "pear",
 "PAER/-D": "pared",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9022,7 +9022,7 @@
 "SUB": "sub",
 "TKRUGS": "drugs",
 "EPBG/TPHAOERS": "engineers",
-"PAEPBLT": "independently",
+"P*EPBLT": "independently",
 "PWUBGT": "bucket",
 "KRER/K-L": "clerical",
 "AEUBG": "ache",


### PR DESCRIPTION
In the current `dict.json` and `top-10000-project-gutenberg-words.json` dictionaries, the single-stroke entry for "independently" is:

```json
"PAEPBLT": "independently",
```

However, that stroke does not seem to exist at all in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33). The Plover single-stroke entry for "independently" is `P*EPBLT`.  Therefore, this PR seeks to:

- Add `"PAEPBLT": "independently"` to `bad-habits.json` to mark it as a mis-stroke
- Change the single-stroke entries for "independently" in `dict.json` and `top-10000-project-gutenberg-words.json` from `PAEPBLT` to `P*EPBLT`.