### PR TITLE
Mark SELGD for "secondly" as a mis-stroke. 

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -465,6 +465,7 @@
 "KWRAOEBG": "Greek",
 "TKPWRAEBG": "Greek",
 "SEFB/APBT": "servant",
+"SELGD": "secondly",
 "STPHAOUG": "institution",
 "TKPW-FT": "government",
 "AOUFRL/PRUBGT/KOED": "Universal Product Code",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -85491,7 +85491,6 @@
 "SEL/U/HRAOEU/TEUS": "cellulitis",
 "SELD/OPL": "seldom",
 "SELG": "selling",
-"SELGD": "secondly",
 "SELS": "sells",
 "SELS/KWRUS": "Celsius",
 "SELS/SKWRUS": "Celsius",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7587,7 +7587,7 @@
 "PERPL/HREU": "permanently",
 "SKWRUPL/-PG": "jumping",
 "PWAEUB": "babe",
-"SELGD": "secondly",
+"SEBLGD": "secondly",
 "SRO*EUPBL": "violin",
 "ROEG": "rogue",
 "RAEUPB/KWREU": "rainy",


### PR DESCRIPTION
Fixes #97.