### PR TITLE
Mark TEPGS stroke for 'tension' as mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -402,6 +402,7 @@
 "TEL/KPHAOUPB/KAEUGS": "telecommunication",
 "TEL/KPHAOUPB/KAEUGS/-S": "telecommunications",
 "TEL/KPHRAOUPB/KAEUGS/-S": "telecommunications",
+"TEPGS": "tension",
 "H*ET/ER": "heather",
 "HOPB/ORBL": "honorable",
 "PWRAO*EU/A*PB": "Bryan",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -107917,7 +107917,6 @@
 "TEPBT/TEUFL": "tentatively",
 "TEPBZ": "tens",
 "TEPD": "tepid",
-"TEPGS": "tension",
 "TEPL/*L": "temple",
 "TEPL/*L/-F/TKEPB/TKUR": "Temple of Dendur",
 "TEPL/*L/TO*PB": "Templeton",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8250,7 +8250,7 @@
 "*ERT/KWAEUBG": "earthquake",
 "SHROEPG": "sloping",
 "SPHAO*LT": "smoothly",
-"TEPGS": "tension",
+"TEPBGS": "tension",
 "SPWRAOEG/-S": "intrigues",
 "TPAOER/TPHREU": "fearfully",
 "PH*/A*/KR*/A*/*U/HR*/A*/KWR*": "Macaulay",


### PR DESCRIPTION
Fixes #100.