### PR TITLE
Mark SKRAUGS stroke for 'concentration' as mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -406,6 +406,7 @@
 "HOPB/ORBL": "honorable",
 "PWRAO*EU/A*PB": "Bryan",
 "PWRAO*EUPB/PWRAO*EUPB": "bryan",
+"SKRAUGS": "concentration",
 "SKWROE/SKWROE": "Joe",
 "SKWROEZ/EF": "Joseph",
 "SKWROES/EF": "Joseph",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -90907,7 +90907,6 @@
 "SKRAPS": "scraps",
 "SKRAU/TPH*EU": "scrawny",
 "SKRAU/TPH*EU/*PBS": "scrawniness",
-"SKRAUGS": "concentration",
 "SKRAUL": "scrawl",
 "SKRAUPB": "scrawn",
 "SKRAUPB/KWR*ES": "scrawniest",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8679,7 +8679,7 @@
 "SEUFLT": "civility",
 "TKEUPBG/KWREU": "dingy",
 "SKAFLD": "scaffold",
-"SKRAUGS": "concentration",
+"SKRAEUGS": "concentration",
 "AFR/EUS": "avarice",
 "SKRAEUP": "scrape",
 "PAOLS": "pools",


### PR DESCRIPTION
Fixes #101.