### PR TITLE
Mark 'Philly-shift' stroke A/PHEUTDZ for 'amidst' as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -432,6 +432,7 @@
 "PHAOEUGT/TEU": "mighty",
 "PHAOEUGT/TEU/*PBS": "mightiness",
 "PHAOEUT/TEU": "mighty",
+"A/PHEUTDZ": "amidst",
 "A*L/PHAOEU/TEU": "Almighty",
 "A*L/PHAOEUG/TEU": "Almighty",
 "A*L/PHAOEUGT/TEU": "Almighty",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -2049,7 +2049,6 @@
 "A/PHEUR": "Amir",
 "A/PHEUS": "amiss",
 "A/PHEUT": "Amit",
-"A/PHEUTDZ": "amidst",
 "A/PHO*D": "method",
 "A/PHO*EUB/SA*EUD": "amino acid",
 "A/PHO*EUP/SA*EUD": "amino acid",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3946,7 +3946,7 @@
 "KPHOPBS": "commons",
 "TPOUL": "foul",
 "HRAOD/-D": "loaded",
-"A/PHEUTDZ": "amidst",
+"A/PH*EUFD": "amidst",
 "TAOEULTS": "titles",
 "APB/SEFT/ORS": "ancestors",
 "TAOEUPS": "types",


### PR DESCRIPTION
Fixes #107.

Note that the choice for the replacement stroke in the Gutenberg dictionary was a result of personal preference. `"A/PH*EUS": "amidst"` would also have been equally valid.