### PR TITLE
Fix strokes for "tiding" and "tidings".

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -972,6 +972,8 @@
 "RATS/KW-BG": "rats,",
 "TORS": "tours",
 "TABGSZ": "taxes",
+"TAOEUD/-G": "tiding",
+"TAOEUD/-G/-S": "tidings",
 "TPHOETD": "noted",
 "PWAEUBS": "babes",
 "PWOBGSZ": "boxes",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4502,7 +4502,7 @@
 "AUT": "aught",
 "HREUFT/-G": "lifting",
 "TPHABG/RAT": "inaccurate",
-"TAOEUGD/-S": "tidings",
+"TAOEUD/-G/-S": "tidings",
 "TPREU": "Friday",
 "KWEULD": "liquid",
 "STAEUG": "staying",


### PR DESCRIPTION
Fixes #108.

Note that the stroke for "tiding" depends on the orthography rules because it changes "tide" to "tiding". 