### PR TITLE
Change stroke entry for "remaining" to have elongated "ā" sound

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -507,6 +507,7 @@
 "A/KHAOEF": "achieve",
 "TKEUS/PRAEUD": "displayed",
 "RE/PHAUPB": "remain",
+"RE/PHAEPBG": "remaining",
 "RE/PHAEUPLT": "replacement",
 "TKE/TPAEUPB": "define",
 "TKE/TPAOEUB": "define",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -77702,7 +77702,6 @@
 "RE/PET/TEUFL": "repetitively",
 "RE/PETS/TEUF": "repetitive",
 "RE/PHAB/EUL/TAEUGS": "rehabilitation",
-"RE/PHAEPBG": "remaining",
 "RE/PHAEUD/KWROS": "Remedios",
 "RE/PHAEUPB": "remain",
 "RE/PHAEUPB/-D": "remained",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2056,7 +2056,7 @@
 "STEPD": "stepped",
 "S-FSZ": "services",
 "HRAOEURB": "library",
-"RE/PHAEPBG": "remaining",
+"RE/PHAEUPBG": "remaining",
 "KAUPB/TAEUPBG": "containing",
 "PWAEUS": "base",
 "KAUFGS": "confusion",


### PR DESCRIPTION
Change stroke for "remaining" to have elongated "ā" sound (`AEU`) and mark existing `RE/PHAEPBG` stroke as a mis-stroke.

Fixes #130.