### PR TITLE
Fix stroke entries for "pronounce" and "pronunciation"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -108,6 +108,8 @@
 "A/HRAOEP": "asleep",
 "PHAPBL/TPHAEUGS": "imagination",
 "PH-PBLG/TPHAEUGS": "imagination",
+"PRO/TPHUPBS/-D": "pronounced",
+"PRO/TPHUPBS/KWRAEUGS": "pronunciation",
 "WAFBG": "watching",
 "TPALT": "fault",
 "TPAL/TEU": "faulty",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -65882,8 +65882,6 @@
 "PRO/TPHREU/TKPWAT": "profligate",
 "PRO/TPHREUG/AT": "profligate",
 "PRO/TPHREUG/SEU": "profligacy",
-"PRO/TPHUPBS/-D": "pronounced",
-"PRO/TPHUPBS/KWRAEUGS": "pronunciation",
 "PRO/TPOR/PHA": "pro forma",
 "PRO/TPORPL/KWRA": "pro forma",
 "PRO/TPORPL/SKWRA": "pro forma",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2991,7 +2991,7 @@
 "WHA/SOFR": "whatsoever",
 "POEUPBGT": "pointing",
 "SRERSZ": "verses",
-"PRO/TPHUPBS/-D": "pronounced",
+"PRO/TPHOUPBS/-D": "pronounced",
 "KPAEUPBG": "exchange",
 "TKEFPBT": "definite",
 "EPL/ROR": "emperor",


### PR DESCRIPTION
Fixes #132.

- Remove "PRO/TPHUPBS/-D": "pronounced", from dict.json
- Remove "PRO/TPHUPBS/KWRAEUGS": "pronunciation", from dict.json
- Add "PRO/TPHUPBS/-D": "pronounced", to bad-habits.json
- Add "PRO/TPHUPBS/KWRAEUGS": "pronunciation", to bad-habits.json
- Change the "pronounced" entry in top-10000-project-gutenberg-words.json from
  PRO/TPHUPBS/-D to PRO/TPHOUPBS/-D