### PR TITLE
Mark EUPB/TPAPT for "infant" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -518,6 +518,7 @@
 "TKEFPL": "definitely",
 "TKEFRPBL": "definitely",
 "EUPB/TED/-D": "intended",
+"EUPB/TPAPT": "infant",
 "EPB/HRORPBLG/-D": "enlarged",
 "APBS/RABL": "answerable",
 "APBS/RER": "answerer",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -18471,7 +18471,6 @@
 "EUPB/TPAPBTS": "infants",
 "EUPB/TPAPL/OUS": "infamous",
 "EUPB/TPAPL/US": "infamous",
-"EUPB/TPAPT": "infant",
 "EUPB/TPARBGS": "infarction",
 "EUPB/TPARBGT": "infarct",
 "EUPB/TPAT/KHAEUGS": "infatuation",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4052,7 +4052,7 @@
 "SOERB": "sober",
 "STAEL": "steal",
 "TKHREUGS": "delicious",
-"EUPB/TPAPT": "infant",
+"EUPB/TPAPBT": "infant",
 "HREUP": "lip",
 "TPHOR/PHAPB": "Norman",
 "OE/TPEPBD/-D": "offended",


### PR DESCRIPTION
Fixes #137.

Mark EUPB/TPAPT for "infant" as a mis-stroke as it drops the `B` for the "n" sound in "-fant". 