### PR TITLE
Mark strokes for "intentions" that do not use full PB stroke for the "n" as mis-strokes

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -77,6 +77,7 @@
 "EUB/PEPB/EPL": "imipenem",
 "EUP/PAPBL": "impanel",
 "EUP/PHRAPB/TAEUGS": "implantation",
+"EUPB/TEPGS/-S": "intentions",
 "EUPB/TKAOES": "induce",
 "EUPB/TKAUS": "induce",
 "EUP/TPRA": "infra",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -18050,7 +18050,6 @@
 "EUPB/TEPBT/PHAOED/KWRA": "Intent Media",
 "EUPB/TEPBTS": "intents",
 "EUPB/TEPD/-D": "intended",
-"EUPB/TEPGS/-S": "intentions",
 "EUPB/TER": "inter",
 "EUPB/TER/AEUL/KWRA": "inter alia",
 "EUPB/TER/AL/KWRA": "inter alia",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4347,7 +4347,7 @@
 "TPRAPB/KHREU": "frankly",
 "REPLD": "recommended",
 "RE/HREF": "relieve",
-"EUPB/TEPGS/-S": "intentions",
+"EUPB/TEPBGS/-S": "intentions",
 "UPB/SKWRUFT": "unjust",
 "HREGT/SHUPB": "legislation",
 "PROPBL": "project",


### PR DESCRIPTION
Fixes #148.