### PR TITLE
Mark strokes for "indulgence" that use LS instead of LG for the "lj" sound as mis-strokes.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -259,6 +259,7 @@
 "EBGS/KPAPBGS": "expansion",
 "EUPB/A/TAPBT/EUF": "inattentive",
 "EUPB/A/TAEPBGS": "inattention",
+"EUPB/TKULS/EPBS": "indulgence",
 "KOPBT/PHRAEUGS": "contemplation",
 "KOPB/TEPL/PHRAEUGS": "contemplation",
 "KOPB/TEPL/PHRAEUT": "contemplate",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -18365,7 +18365,6 @@
 "EUPB/TKULG/EPBS": "indulgence",
 "EUPB/TKULG/EPBT": "indulgent",
 "EUPB/TKULGD": "indulged",
-"EUPB/TKULS/EPBS": "indulgence",
 "EUPB/TKUPBGS": "induction",
 "EUPB/TKUR/AEUGS": "induration",
 "EUPB/TKURGS": "induration",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5753,7 +5753,7 @@
 "EUPB/KREUPGS": "inscription",
 "KAEBL": "comfortably",
 "EUPB/TKULG": "indulge",
-"EUPB/TKULS/EPBS": "indulgence",
+"EUPB/TKULG/EPBS": "indulgence",
 "PWRAEUFL": "bravely",
 "TPHAOELG": "kneeling",
 "KWRA*EU": "yea",


### PR DESCRIPTION
Fixes #151.