### PR TITLE
Mark stroke for "overwhelmed" that uses K instead of W when beginning "-whelm" as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -51,6 +51,7 @@
 "EP/SAO*EUPL": "enzyme",
 "EP/TAOEUR": "entire",
 "A/SAOEUB": "assign",
+"AUFR/KHEPLD": "overwhelmed",
 "AUFRT/KWRAP": "Austrian",
 "KPAFBGT/PWAUL": "basketball",
 "PWAFBT/PWAUL": "basketball",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -11875,7 +11875,6 @@
 "AUFR/HRAPS": "overlaps",
 "AUFR/KAEUPL": "overcame",
 "AUFR/KAFT": "overcast",
-"AUFR/KHEPLD": "overwhelmed",
 "AUFR/KOPL": "overcome",
 "AUFR/KPEPBS/AEUGS": "overcompensation",
 "AUFR/KPEPBS/AEUT": "overcompensate",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5826,7 +5826,7 @@
 "HAEUS/-PB": "hasten",
 "TPORPB/ER/-S": "foreigners",
 "ERLD": "elderly",
-"AUFR/KHEPLD": "overwhelmed",
+"AUFR/WHEPLD": "overwhelmed",
 "EUPB/STEUPBGS": "instincts",
 "TEL/TKPWRAF": "telegraph",
 "RUS/SEL": "Russell",


### PR DESCRIPTION
Fixes #152.