### PR TITLE
Fix entries containing "enchant" to use the full KH stroke for the "ch" sound. 

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -59,6 +59,7 @@
 "ER/TAEUT": "irritate",
 "UPB/KOUPBT/ER": "encounter",
 "UPB/HO/PHOPBLG/TPHAEUT": "inhomogeneity",
+"EPB/HAPBT": "enchant",
 "EPB/HERT": "inherit",
 "EPB/KORBLG/-D": "encouraged",
 "EPB/KORPBG": "encourage",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -293,6 +293,7 @@
 "TKEUS/KWAO*EUT": "disquiet",
 "TKURB/*ERS": "disturbers",
 "AOE/HROP/*EPLT": "elopement",
+"EPB/KHAPBT/-D": "enchanted",
 "EPB/TKPWROS": "engross",
 "EPB/TKPWROS/-G": "engrossing",
 "EPB/SEUPB/SEU": "ensigncy",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -14725,7 +14725,6 @@
 "EPB/HAPBS/-S": "enhances",
 "EPB/HAPBS/O*R": "enhancer",
 "EPB/HAPBSZ": "enhances",
-"EPB/HAPBT": "enchant",
 "EPB/HAPLT": "enhancement",
 "EPB/HR*EUS": "enlist",
 "EPB/HR*EUS/*PLT": "enlistment",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6967,7 +6967,7 @@
 "ODZ": "odds",
 "AEUPLS": "aims",
 "EUL/AOUPL/TPHAEUT/-D": "illuminated",
-"EPB/HAPBT/-D": "enchanted",
+"EPB/KHAPBT/-D": "enchanted",
 "AD/SRERS/REU": "adversary",
 "PAOEU": "pie",
 "RAOE/TPHREBGT/-G": "reflecting",


### PR DESCRIPTION
Fixes #165.