### PR TITLE
Mark "inscrib*" words that do not use an S stroke as mis-strokes

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -99,6 +99,8 @@
 "EUB/PEPB/EPL": "imipenem",
 "EUP/PAPBL": "impanel",
 "EUP/PHRAPB/TAEUGS": "implantation",
+"EUPB/KRAOEUB": "inscribe",
+"EUPB/KRAOEUB/-G": "inscribing",
 "EUPB/TEPGS/-S": "intentions",
 "EUPB/TKAOES": "induce",
 "EUPB/TKAUS": "induce",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -17031,8 +17031,6 @@
 "EUPB/KRAOES/-S": "increases",
 "EUPB/KRAOES/TKPWHREU": "increasingly",
 "EUPB/KRAOET/*EUPB": "incretin",
-"EUPB/KRAOEUB": "inscribe",
-"EUPB/KRAOEUB/-G": "inscribing",
 "EUPB/KRAOEUT": "incite",
 "EUPB/KRAOUGS/TPHAER": "inclusionary",
 "EUPB/KRAOUT/-BL": "inscrutable",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8006,7 +8006,7 @@
 "PWURG/TKEU": "burgundy",
 "KHREBGS/-S": "collections",
 "UPB/KAOEUPBD": "unkind",
-"EUPB/KRAOEUB/-D": "inscribed",
+"EUPB/SKRAOEUB/-D": "inscribed",
 "KURB/OPBS": "cushions",
 "PRA*RPL": "programme",
 "TKEUPB": "din",


### PR DESCRIPTION
Fixes #172.