### PR TITLE
Change stroke for "heritage" to use "e" sound, rather than "a".

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -106,6 +106,7 @@
 "PUR/KWREUD/-FPLT": "buried{.}",
 "RAOUBG/RAT/EUF": "lucrative",
 "RAOURB/KAEUT/-G": "lubricating",
+"HAR/TAPBLG": "heritage",
 "HEUPLT": "limit",
 "HEURT": "liter",
 "HOUD/*ER": "louder",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -22401,7 +22401,6 @@
 "HAR/SREFT/*ER": "harvester",
 "HAR/SRES/TER": "harvester",
 "HAR/SREU": "Harvey",
-"HAR/TAPBLG": "heritage",
 "HAR/TEU": "hearty",
 "HAR/TEU/*PBS": "heartiness",
 "HAR/TEU/HREU": "heartily",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8958,7 +8958,7 @@
 "PHAPB/TPEFT/HREU": "manifestly",
 "PHAR/KOE": "Marco",
 "PWA/TAL/KWROPB": "battalion",
-"HAR/TAPBLG": "heritage",
+"HER/TAPBLG": "heritage",
 "PWROER/HAOD": "brotherhood",
 "TPHUPB": "nun",
 "WAD": "wad",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "heritage", all of which are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33):

```json
"HAR/TAPBLG": "heritage",
"HER/TAPBLG": "heritage",
"HERT/APBLG": "heritage",
```

In the `top-10000-project-gutenberg-words.json` dictionary, the stroke used for "heritage" is:

https://github.com/didoesdigital/steno-dictionaries/blob/fe5055bfcf402bf7937ec74143fc18934e207788/dictionaries/top-10000-project-gutenberg-words.json#L8961

The "a" sound in the stroke for "heritage" looks like a mis-stroke to me, so this PR proposes:

- Removing `"HAR/TAPBLG": "heritage"` from `dict.json`
- Adding `"HAR/TAPBLG": "heritage""` to `bad-habits.json`
- In `top-10000-project-gutenberg-words.json` change:
  - before: `"HAR/TAPBLG": "heritage"`
  - after: `"HER/TAPBLG": "heritage"`