### PR TITLE
Add `H` stroke to entry for "clerical"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -739,6 +739,7 @@
 "UPB/SERPT": "uncertainty",
 "SKEUGS": "decision",
 "TPHAT/TPHAT": "Nat",
+"KRER/K-L": "clerical",
 "KRERBG": "correct",
 "KPERBL": "commercial",
 "KPHERL": "commercial",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -41961,7 +41961,6 @@
 "KREPT/REU": "century",
 "KREPT/SKWRUS": "crepitus",
 "KRER": "cartographer",
-"KRER/K-L": "clerical",
 "KRERB": "creche",
 "KRERB/EPB/TKOE": "crescendo",
 "KRERB/KWREPB/TKOE": "crescendo",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9024,7 +9024,7 @@
 "EPBG/TPHAOERS": "engineers",
 "P*EPBLT": "independently",
 "PWUBGT": "bucket",
-"KRER/K-L": "clerical",
+"KHRER/K-L": "clerical",
 "AEUBG": "ache",
 "TKPWHREUT": "glitter",
 "ORPBS": "ordinance",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "clerical", all of which are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33):

```json
"KHRAOERBL/K-L": "clerical",
"KHRER/K-L": "clerical",
"KHRER/KAL": "clerical",
"KHRERBG/A*L": "clerical",
"KHRERBG/K-L": "clerical",
"KRER/K-L": "clerical",
```

In the `top-10000-project-gutenberg-words.json` dictionary, the stroke used for "clerical" is:

https://github.com/didoesdigital/steno-dictionaries/blob/fe5055bfcf402bf7937ec74143fc18934e207788/dictionaries/top-10000-project-gutenberg-words.json#L9027

`"KRER/K-L": "clerical"` without the `H` stroke to make the `HR` "l" sound looks like a mis-stroke to me, so this PR proposes:

- Removing `"KRER/K-L": "clerical"` from `dict.json`
- Adding `"KRER/K-L": "clerical"` to `bad-habits.json`
- In `top-10000-project-gutenberg-words.json` change:
  - before: `"KRER/K-L": "clerical"`
  - after: `"KHRER/K-L": "clerical"`