### PR TITLE
Have Gutenberg dictionary use `PERS/APBLG` stroke for "percentage"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9548,7 +9548,7 @@
 "EBGS/ABGT/-G": "exacting",
 "PAR/-FPD": "parched",
 "ED/TKEU": "eddy",
-"PER/APBLG": "percentage",
+"PERS/APBLG": "percentage",
 "TWEUPBG/*L": "twinkle",
 "KURB": "curb",
 "SAPBD/STOEPB": "sandstone",


### PR DESCRIPTION
In the `top-10000-project-gutenberg-words.json` dictionary, the stroke used for "percentage" is:

https://github.com/didoesdigital/steno-dictionaries/blob/fb0fd2fb03b97163c8147363a66ad54130b8e427/dictionaries/top-10000-project-gutenberg-words.json#L9551

I don't think this stroke is a mis-stroke, but I would like to propose that `PERS/APBLG` with an `S` stroke is a more intuitive entry pronunciation-wise, and it would be good to have Typey Type use it.