### PR TITLE
Mark stroke for "harmonious" without a leading `H` as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -1,4 +1,5 @@
 {
+"AR/PHOEPB/KWROUS": "harmonious",
 "SOER/KWRUS/-PBS": "seriousness",
 "SAOER/KWRUS": "serious",
 "SAOER/KWRUS/HREU": "seriously",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -10837,7 +10837,6 @@
 "AR/PHAT/EUBG": "aromatic",
 "AR/PHEU": "army",
 "AR/PHEU/STEUS": "armistice",
-"AR/PHOEPB/KWROUS": "harmonious",
 "AR/PHOEUR": "armory",
 "AR/PHOPBD/O*": "Armando",
 "AR/PHOR": "armor",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8001,7 +8001,7 @@
 "HAEUBG": "headache",
 "TAEPBT": "tenant",
 "PWURPBS": "burns",
-"AR/PHOEPB/KWROUS": "harmonious",
+"HAR/PHOEPB/KWROUS": "harmonious",
 "TKRAOE/PH*EU": "dreamy",
 "PWURG/TKEU": "burgundy",
 "KHREBGS/-S": "collections",


### PR DESCRIPTION
Fixes #221.