### PR TITLE
Have Gutenberg dictionary use `OBG/PAOEU` outline with a long "ī" for "occupy"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3932,7 +3932,7 @@
 "HOEURS": "heroes",
 "EUPB/SREUBL": "invisible",
 "WEL/H-PB/TPHOEPB": "well-known",
-"OBG/PEU": "occupy",
+"OBG/PAOEU": "occupy",
 "SKWRAEU/KOB": "Jacob",
 "TKPWOUPB": "gown",
 "KRAOULT": "cruelty",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "occupy", all of which are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33):

```json
"OBG/KAOU/PEU": "occupy",
"OBG/KWRAOU/PEU": "occupy",
"OBG/KWRU/PEU": "occupy",
"OBG/PAOEU": "occupy",
"OBG/PEU": "occupy",
```

In the `top-10000-project-gutenberg-words.json` dictionary, the stroke used for "occupy" is:

https://github.com/didoesdigital/steno-dictionaries/blob/e9408eec8e47755e728bb1d68fce29a58ba0f121/dictionaries/top-10000-project-gutenberg-words.json#L3935

Out of all the outlines listed above, `"OBG/PAOEU": "occupy"` with the long "ī" seems like the most correct pronunciation-wise, but since it's the only one that _does_ use  the long "ī", I don't think I can reasonably propose that all the rest are mis-strokes. I do think, though, that `OBG/PAOEU` should appear in Typey Type, and so would like to propose:

- In `top-10000-project-gutenberg-words.json` change:
  - before: `"OBG/PEU": "occupy"`
  - after: `"OBG/PAOEU": "occupy"`