### PR TITLE
Change outline used for "successor" in Gutenberg to one without an asterisk.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5118,7 +5118,7 @@
 "WOPBD/TPHREU": "wonderfully",
 "PHA*BGS": "max",
 "WA*PB": "Juan",
-"SUBG/SES/O*R": "successor",
+"SUBG/SES/SOR": "successor",
 "A/HRAOEU/-D": "allied",
 "KAOELG": "ceiling",
 "K-FRPLGS": "confirmation",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "successor", all of which are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33):

```json
"SUBG/SES/O*R": "successor",
"SUBG/SES/SOR": "successor",
"SUBG/SESZ/SOR": "successor",
```

In the `top-10000-project-gutenberg-words.json` dictionary, the stroke used for "successor" is:

https://github.com/didoesdigital/steno-dictionaries/blob/e9408eec8e47755e728bb1d68fce29a58ba0f121/dictionaries/top-10000-project-gutenberg-words.json#L5121

I wouldn't argue that `"SUBG/SES/O*R": "successor"` is a mis-stroke, but this PR proposes that `"SUBG/SES/SOR": "successor"` is a better fit spelling-wise (with a "double-s"), and it doesn't require an asterisk.