### PR TITLE
Add condensed stroke for "offensive".

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -639,6 +639,7 @@
 "OEUFRT/PHURB/RAOPLS": "oyster mushrooms",
 "OEUR/SKWREPB/TAL": "urogenital",
 "OF/EPBS": "offence",
+"OFPBS/EUF": "offensive",
 "OLD/*EPB": "olden",
 "OLD/H-PB/TPAGS/-D": "old-fashioned",
 "ORG/A*L/A*U/SREPLT": "organisational development",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5240,7 +5240,7 @@
 "PRAOEGS": "appreciation",
 "SPREFD": "suppressed",
 "A/KWAOEU": "acquire",
-"OFPBS/*EUF": "offensive",
+"OFPBS/EUF": "offensive",
 "RAOEUP": "ripe",
 "TKRES/-S": "dresses",
 "RAEPB/-D": "reigned",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "offensive", all of which are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33):

```json
"O/TPEPBS/*EUF": "offensive",
"OE/TPEPBS/EUF": "offensive",
"OFPBS/*EUF": "offensive",
```

In the `top-10000-project-gutenberg-words.json` dictionary, the stroke used for "offensive" is:

https://github.com/didoesdigital/steno-dictionaries/blob/e9408eec8e47755e728bb1d68fce29a58ba0f121/dictionaries/top-10000-project-gutenberg-words.json#L5243

I don't think that any of these are mis-strokes, but since the outlines for the `{^ive}` suffix cover both `*EUF` and `EUF`, it would seem to make sense to me to use the asterisk-less version where possible.

So, this PR proposes to add `"OFPBS/EUF": "offensive"` to `dict.json` as a condensed stroke, and use it in the Gutenberg dictionary.