### PR TITLE
Add condensed stroke for "politeness" that uses the `-PBS` {^ness} suffix

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -752,6 +752,7 @@
 "PHRAEUG/-D": "plagued",
 "PHRAEUPB/*ER": "plainer",
 "PHRAEUT/-FL": "plateful",
+"PHRAOEUT/-PBS": "politeness",
 "PHREFPBT/*ER": "pleasanter",
 "PHREFPBT/-PBS": "pleasantness",
 "PHREFPBT/EFT": "pleasantest",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6141,7 +6141,7 @@
 "PWAR/KWRER": "barrier",
 "KA/TPHAEUD/KWRAPB": "Canadian",
 "KUFRB": "curve",
-"PHRAOEUT/*PBS": "politeness",
+"PHRAOEUT/-PBS": "politeness",
 "TPHROER": "flora",
 "RE/HREU": "rely",
 "TPHRA*PBG": "flank",


### PR DESCRIPTION
This PR proposes to add a condensed stroke for "politeness" that uses the `-PBS` {^ness} suffix, and use it in the Gutenberg dictionary and Typey Type.