### PR TITLE
Add new Plover single-stroke outline for "kettle"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -29355,6 +29355,7 @@
 "K*EG": "EKG",
 "K*EGT": "context",
 "K*EL/OG": "Kellogg",
+"K*ELT": "kettle",
 "K*EPB": "Ken",
 "K*EPB/HROG": "Kenalog",
 "K*EPBGS": "contraception",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7507,7 +7507,7 @@
 "SEUG/TPEU": "signify",
 "HRAEUR": "layer",
 "KHRAOU": "clue",
-"KET/*L": "kettle",
+"K*ELT": "kettle",
 "KAUPB/TPHRAEUT": "contemplate",
 "A/TPOR/SAEUD": "aforesaid",
 "TAO*T": "tooth",


### PR DESCRIPTION
This PR proposes to add in the `K*ELT` Plover outline for "kettle" to `dict.json`, and use it in the Gutenberg dictionary.