### PR TITLE
Change vowel from `A` to `E` in outline for "Rebecca".

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7324,7 +7324,7 @@
 "POP/HRAS": "populace",
 "SHER/PHAPB": "Sherman",
 "EUPB/SEPBS": "incense",
-"RE/PWABG/KA": "Rebecca",
+"RE/PWEBG/KA": "Rebecca",
 "SKWROR/TKAPB": "Jordan",
 "PERPBT": "persistent",
 "W*EU": "Wisconsin",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "Rebecca":

```json
"RE/PWABG/KA": "Rebecca",
"RE/PWEBG/KA": "Rebecca",
```

This PR proposes to change the Gutenberg outline for "Rebecca" to use an `E`, rather than `A` stroke. I don't necessarily think that `RE/PWABG/KA` is a mis-stroke, but `RE/PWEBG/KA` reads more correctly to me.