### PR TITLE
Add new `RARLD` outline for "regardless" and have the Gutenberg dictionary use it.

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -76731,6 +76731,7 @@
 "RARD/HRES": "regardless",
 "RARDZ": "regards",
 "RARGD": "regarding",
+"RARLD": "regardless",
 "RARLD/-LS": "regardless",
 "RARLDZ": "regardless",
 "RARPB": "rather than",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8242,7 +8242,7 @@
 "SPWHRAPBS": "semblance",
 "PALS/TAOEUPB": "Palestine",
 "PERP/KHRAR": "perpendicular",
-"RARLDZ": "regardless",
+"RARLD": "regardless",
 "TPEFRB/EPBT": "fervent",
 "SAEUPB": "sane",
 "WRAO*ET": "wreath",


### PR DESCRIPTION
This PR proposes to add Plover [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s `"RARLD": "regardless"` outline, and prefer it in Typey-Type due to not having to stroke `DZ`.