### PR TITLE
Add new Plover `KHROFL` outline for "colossal" and have the Gutenberg dictionary use it.

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -36017,6 +36017,7 @@
 "KHROEZ/KWRURS": "closures",
 "KHROEZ/PAOEUPB": "clozapine",
 "KHROEZ/SHUR": "closure",
+"KHROFL": "colossal",
 "KHROFRPLT": "color{.}",
 "KHROFT": "closet",
 "KHROFT/REUD/KWRUPL": "Clostridium",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8393,7 +8393,7 @@
 "WUP/PWORD": "cupboard",
 "HRAOUD/KRUS": "ludicrous",
 "AUPLS": "alms",
-"KHROS/A*L": "colossal",
+"KHROFL": "colossal",
 "STAOUPD/TEU": "stupidity",
 "PHOPB/OT/TPHEU": "monotony",
 "SHRUS": "stimulus",


### PR DESCRIPTION
This PR proposes to add Plover [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s single-stroke `"KHROFL": "colossal"` outline, and prefer it in Typey-Type.