### PR TITLE
Fix errors with outline for "flutter", and add "-er" suffixes.

### DIFF
--- a/dictionaries/nouns.json
+++ b/dictionaries/nouns.json
@@ -444,7 +444,7 @@
 "TPHA*EL/SA*EUGS": "internationalization",
 "TPHA*F": "nav",
 "TPHA*UT": "nought",
-"TPHRUT": "flutter",
+"TPHRUT/ER": "flutter",
 "TPO*EPB": "iPhone",
 "UBGS/UBGS": "UX",
 "UPB/HRUBG/KWREFT": "unluckiest",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8684,7 +8684,7 @@
 "SKRAEUP": "scrape",
 "PAOLS": "pools",
 "AOR": "oar",
-"TPHRUT": "flutter",
+"TPHRUT/ER": "flutter",
 "PHAR/TER": "martyr",
 "HAPB/TKEU": "handy",
 "PHOPBT/TKPWAOU": "Montague",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "flutter", all of which are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33):

```json
"TPHRUT/*ER": "flutter",
"TPHRUT/ER": "flutter",
"TPHRUT/TER": "flutter",
```

In the `top-10000-project-gutenberg-words.json` and `nouns.json` dictionaries, the stroke used for "flutter" is:

https://github.com/didoesdigital/steno-dictionaries/blob/cd9048411754dddb3c3e043134b2f8e85f952908/dictionaries/top-10000-project-gutenberg-words.json#L8687

https://github.com/didoesdigital/steno-dictionaries/blob/cd9048411754dddb3c3e043134b2f8e85f952908/dictionaries/nouns.json#L447

Since `"TPHRUT": "flutter"` is not in `dict.json`, nor is it in Plover, I can only assume these entries are input typos...? Assuming that, this PR proposes to fix the `"TPHRUT": "flutter"` entries to `"TPHRUT/ER": "flutter"`.