### PR TITLE
Add `TKPWHREURT` outline for "glitter"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -117969,6 +117969,7 @@
 "TKPWHREUPLS": "glimpse",
 "TKPWHREURB": "English",
 "TKPWHREURPL": "glimmer",
+"TKPWHREURT": "glitter",
 "TKPWHREUS/*EPB": "glisten",
 "TKPWHREUS/-PB": "glisten",
 "TKPWHREUS/-PB/-D": "glistened",

--- a/dictionaries/nouns.json
+++ b/dictionaries/nouns.json
@@ -432,7 +432,7 @@
 "TKPWAEUP/-G": "gaping",
 "TKPWAEUPL/TPAEUBGS": "gamification",
 "TKPWAEUPL/TPAOEU": "gamify",
-"TKPWHREUT": "glitter",
+"TKPWHREURT": "glitter",
 "TKPWRAEU/PWOBGS": "graybox",
 "TKPWRAEU/PWOBGS/-D": "grayboxed",
 "TKPWRAEU/PWOBGS/-G": "grayboxing",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9026,7 +9026,7 @@
 "PWUBGT": "bucket",
 "KHRER/K-L": "clerical",
 "AEUBG": "ache",
-"TKPWHREUT": "glitter",
+"TKPWHREURT": "glitter",
 "ORPBS": "ordinance",
 "PWAPL/PWAO": "bamboo",
 "AFPS/TKAPL": "Amsterdam",


### PR DESCRIPTION
It looks like the `TKPWHREUT` outline for "glitter" is either a typo or was changed in a later release of Plover (or perhaps it was a condensed stroke since it wasn't originally entered into `dict.json`...?), so this PR proposes to change `TKPWHREUT` outlines for the now-correct `TKPWHREURT`.