### PR TITLE
Add Plover `SELD` outline for "seldom" and use it in the Gutenberg dictionary

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -85140,6 +85140,7 @@
 "SEL/TPEURB": "selfish",
 "SEL/TPEURB/*PBS": "selfishness",
 "SEL/U/HRAOEU/TEUS": "cellulitis",
+"SELD": "seldom",
 "SELD/OPL": "seldom",
 "SELG": "selling",
 "SELS": "sells",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1980,7 +1980,7 @@
 "PARD": "pardon",
 "TKPWAEU": "gay",
 "PWEG": "beg",
-"SELD/OPL": "seldom",
+"SELD": "seldom",
 "KEUPBDZ": "kinds",
 "RORD": "record",
 "TPAT": "fat",


### PR DESCRIPTION
I don't think any of the current outlines for "seldom" in the dictionary are mis-strokes, so this PR just proposes to add Plover's `SELD` outline, and use it in Typey-Type.