### PR TITLE
Add Plover `KHAOEUPBZ` outline for "Chinese"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -34272,6 +34272,7 @@
 "KHAOEUPB/TPHA": "China",
 "KHAOEUPB/TPHAOEZ": "Chinese",
 "KHAOEUPB/WRA": "China",
+"KHAOEUPBZ": "Chinese",
 "KHAOEUPL": "chime",
 "KHAOEUPL/KWRO": "{chymo^}",
 "KHAOEUPL/SKWRO": "{chymo^}",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2286,7 +2286,7 @@
 "TEUS": "'tis",
 "TPARPL": "farm",
 "REFRPBS": "reference",
-"KHAOEUPB/AOES": "Chinese",
+"KHAOEUPBZ": "Chinese",
 "KPEUFT": "exist",
 "KORPB": "corn",
 "A/PROEFPG": "approaching",


### PR DESCRIPTION
This PR proposes to add Plover's `KHAOEUPBZ` outline for "Chinese", and have it be used in the Gutenberg dictionary.