### PR TITLE
Add `TPURPB/-D` condensed stroke for "furnished"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1475,6 +1475,7 @@
 "TPRERB/EFT": "freshest",
 "TPRET/TPHREU": "fretfully",
 "TPRO/WA*RD": "froward",
+"TPURPB/-D": "furnished",
 "TPWHREURB/SPEUPB/AFP": "English spinach",
 "TRAFL/HREUPBG": "travelling",
 "TRERB/-D": "treasured",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2307,7 +2307,7 @@
 "KWAEULGS": "occasionally",
 "KWR*": "y",
 "WAEBG/-PBS": "weakness",
-"TPURPB/EURBD": "furnished",
+"TPURPB/-D": "furnished",
 "KHOEUPB": "China",
 "PRAOEFT/-S": "priests",
 "TPHRAOEUG": "flying",


### PR DESCRIPTION
This PR proposes to add a `TPURPB/-D` condensed stroke for "furnished" to mirror the `TPURPB` outline for "furnish".

It also proposes to use it in the Gutenberg dictionary as the current `TPURPB/EURBD` outline, while valid in Plover and not looking like a mis-stroke pronunciation-wise, makes you essentially stroke "furnish-ished".