### PR TITLE
Change "a" vowel in "maintain" outline to be an "ā"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2555,7 +2555,7 @@
 "SRO*L": "vol",
 "HRAOEPBD": "leaned",
 "KHREPBLG": "college",
-"PHEUPB/TAEUPB": "maintain",
+"PHAEUPB/TAEUPB": "maintain",
 "SOFRPB": "sovereign",
 "TAEUL": "tail",
 "SKWREPB/RAEUGS": "generation",


### PR DESCRIPTION
I think that "main" and "tain" both (generally) have a long "ā" vowel sound, so this PR proposes to change the entry in Gutenberg to make both those vowel sounds the same in the outline for "maintain".

I'm hesitant to consider `PHEUPB/TAEUPB` a mis-stroke due to potential human accent variations, but I do think `PHAEUPB/TAEUPB` sounds _more_ correct.