### PR TITLE
Change "o" vowel in "obey" outline to be an "ō"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2633,7 +2633,7 @@
 "RAOEURS": "requires",
 "TPAURS": "fathers",
 "PRO/SPEBGT": "prospect",
-"O/PWAEU": "obey",
+"OE/PWAEU": "obey",
 "KPHRAPBD/*ER": "Alexander",
 "SHO*EPB": "shone",
 "OERPGS": "operation",


### PR DESCRIPTION
This PR proposes to change the "obey" outline in Gutenberg to give it a "ō" vowel.

I'm hesitant to consider `O/PWAEU` a mis-stroke due to potential human accent variations, but I do think `OE/PWAEU` sounds _more_ correct in this case.