### PR TITLE
Mark `KUPB/SEUL` for "council" as a mis-stroke due to missing the "o" vowel

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -345,6 +345,7 @@
 "KRER/K-L": "clerical",
 "KRERBG": "correct",
 "KRO": "{co-^}",
+"KUPB/SEUL": "council",
 "KW-B": "{,}",
 "KW-BG/PHOEUFP/KW-BG": "{,}",
 "KW-BLG": "{,}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -42907,7 +42907,6 @@
 "KUPB/HREUPBG/TKPWUS": "cunnilingus",
 "KUPB/HREUPBG/US": "cunnilingus",
 "KUPB/PWA/WA": "Konbanwa",
-"KUPB/SEUL": "council",
 "KUPB/TAPL/TPHAPBT": "contaminant",
 "KUPB/TKPWHREU": "cunningly",
 "KUPB/TKRUPL": "conundrum",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2698,7 +2698,7 @@
 "SROLD": "involved",
 "SUPB/SHAO*EUPB": "sunshine",
 "TKUFP": "Dutch",
-"KUPB/SEUL": "council",
+"KOUPB/SEUL": "council",
 "PREUPBS/-S": "princes",
 "AEUT": "ate",
 "KP-GS": "examination",


### PR DESCRIPTION
This PR proposes to mark `KUPB/SEUL` as a mis-stroke due to the missing "o" vowel in "council", and have the Gutenberg dictionary use `KOUPB/SEUL` as the most accurate outline.