### PR TITLE
Add Plover `TPH-FPBT` outline for "infinite"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -125166,6 +125166,7 @@
 "TPH-FP/-G": "inching",
 "TPH-FP/-S": "inches",
 "TPH-FPBLGT": "income{.}",
+"TPH-FPBT": "infinite",
 "TPH-FPLGTS": "in{.}",
 "TPH-FPLT": "in{.}",
 "TPH-FPLT/KWR*BG": "N.Y.C.",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2673,7 +2673,7 @@
 "OD": "odd",
 "TKPWRA*EUFL": "grateful",
 "TPHAOER/EFT": "nearest",
-"EUFPB/TPHEUT": "infinite",
+"TPH-FPBT": "infinite",
 "ELS/W-R": "elsewhere",
 "KOP/EUG": "copying",
 "ARPLT": "apartment",


### PR DESCRIPTION
This PR proposes to add the Plover `TPH-FPBT` outline for "infinite", and use it in the Gutenberg dictionary.