### PR TITLE
Change "obedience" outline used in Gutenberg dictionary to long "ō" vowel.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3014,7 +3014,7 @@
 "SKWREPB/WEUPB": "genuine",
 "HARPL/-LS": "harmless",
 "PHEUPBG/-LD": "mingled",
-"O/PWAOED/KWREPBS": "obedience",
+"OE/PWAOED/KWREPBS": "obedience",
 "WAUBGS": "walks",
 "TRAEUPBG": "training",
 "PWAD/HREU": "badly",


### PR DESCRIPTION
`O/PWAOED/KWREPBS` does not look like a mis-stroke to me, but I think that `OE/PWAOED/KWREPBS` with an "ō" vowel is a bit more correct pronunciation-wise, so this PR proposes to change the entry in Gutenberg to use it.