### PR TITLE
Mark `SROL/TKPWAR` for "vulgar" as a mis-stroke due to the "o" vowel

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -581,6 +581,7 @@
 "SRAPBG/PHAOEUS/*EUB": "vancomycin",
 "SRAUTS": "vaults",
 "SREURPBLG/*EUB": "virgin",
+"SROL/TKPWAR": "vulgar",
 "SROUBD/-D": "surrounded",
 "STAOES": "disease",
 "STAPBLG/-S": "strategies",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -99472,7 +99472,6 @@
 "SROL/TEUL": "volatile",
 "SROL/TEUL/TEU": "volatility",
 "SROL/TEULT": "volatility",
-"SROL/TKPWAR": "vulgar",
 "SROL/TPHOUS": "voluminous",
 "SROL/TPHUS": "voluminous",
 "SROL/TREU": "voluntary",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3580,7 +3580,7 @@
 "TKAOR/WAEU": "doorway",
 "KHRAOEUPLD": "climbed",
 "SROLS": "volumes",
-"SROL/TKPWAR": "vulgar",
+"SRUL/TKPWAR": "vulgar",
 "AERPLTS": "arguments",
 "1/S*/T*": "1st",
 "SAUPB/SET": "sunset",


### PR DESCRIPTION
`SROL/TKPWAR` for "vulgar" seems like a mis-stroke to me, so this PR proposes to move it to `bad-habits.json` and have the Gutenberg dictionary use the other `SRUL/TKPWAR` Plover outline for "vulgar".