### PR TITLE
Fix outline for "Bonaparte" to be Plover's entry of `PWOEPB/PA*RT`

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -470,6 +470,7 @@
 "PWHRAPBG": "blank",
 "PWHRAPGT": "blanket",
 "PWO*EUD": "PWO*ED body misstroke",
+"PWOEPB/PART": "Bonaparte",
 "PWOPBG/KWROEL": "bronchiole",
 "PWOUBD/REU": "boundary",
 "PWRA*PBG": "blank",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -71690,7 +71690,7 @@
 "PWOEPB/KWRA/TPAOEUD": "bona fide",
 "PWOEPB/KWRER": "bonier",
 "PWOEPB/KWREU": "bony",
-"PWOEPB/PART": "Bonaparte",
+"PWOEPB/PA*RT": "Bonaparte",
 "PWOEPB/PHAOEL": "bone meal",
 "PWOEPB/SAO*EU": "bonsai",
 "PWOEPB/SAOEU": "bonsai",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4133,7 +4133,7 @@
 "KPER/SAOEUZ/-D": "exercised",
 "WEL/TH*EU": "wealthy",
 "SAOEPL/-G": "seeming",
-"PWOEPB/PART": "Bonaparte",
+"PWOEPB/PA*RT": "Bonaparte",
 "SHOUGT": "shouting",
 "THAPBGD": "thanked",
 "EUL/HRUS/TROUS": "illustrious",


### PR DESCRIPTION
`PWOEPB/PART` outputs "bone part" in vanilla Plover, so this PR proposes to change the outline for "Bonaparte" to be Plover's `PWOEPB/PA*RT` entry.