### PR TITLE
Mark `TKELG/RAEUGS` outline for "declaration" as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -692,6 +692,7 @@
 "TKEFPBL": "definitely",
 "TKEFPL": "definitely",
 "TKEFRPBL": "definitely",
+"TKELG/RAEUGS": "declaration",
 "TKEUD/RARD/-D": "disregarded",
 "TKEUS/PRAEUD": "displayed",
 "TKEUS/RART/-D": "disregarded",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -113033,7 +113033,6 @@
 "TKEL/TPHOR/TAEU": "Del Norte",
 "TKEL/WAER": "Delaware",
 "TKEL/WAEUR": "Delaware",
-"TKELG/RAEUGS": "declaration",
 "TKELT": "dealt",
 "TKELT/KWRA": "delta",
 "TKELT/OEUD": "deltoid",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4307,7 +4307,7 @@
 "PWER/HREUPB": "Berlin",
 "ED/EUT/-G": "editing",
 "KAPL/PWREUPBLG": "Cambridge",
-"TKELG/RAEUGS": "declaration",
+"TKEBG/HRAEUGS": "declaration",
 "TKPWARDZ": "guards",
 "PERPBLT": "personality",
 "SPHAUL/EFT": "smallest",


### PR DESCRIPTION
In the current `dict.json` file, there are the following strokes for "declaration", all of which are valid in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33):

```json
"TKE/KHRA/RAEUGS": "declaration",
"TKE/KHRAR/AEUGS": "declaration",
"TKEBG/HRA/RAEUGS": "declaration",
"TKEBG/HRAEUGS": "declaration",
"TKEBG/HRAR/AEUGS": "declaration",
"TKELG/RAEUGS": "declaration",
"TKERBG/HRAEUGS": "declaration",
```

In the `top-10000-project-gutenberg-words.json` dictionary, the stroke used for "declaration" is:

https://github.com/didoesdigital/steno-dictionaries/blob/6fcda7395ef4b30925638d729ec5b53305911a81/dictionaries/top-10000-project-gutenberg-words.json#L4310

I'm not sure what rules the `TKELG/RAEUGS` is following to get "declaration". It reads to me like "deljration" or "delchration" (or perhaps it's reading `G` as "k" and doing an inversion with the `L`...?), and since it's the only outline of the set that uses `LG`, it looks to me like a mis-stroke. So, I'd like to propose:

- Removing `"TKELG/RAEUGS": "declaration"` from `dict.json`
- Adding `"TKELG/RAEUGS": "declaration"` to `bad-habits.json`
- In `top-10000-project-gutenberg-words.json` change:
  - before: `"TKELG/RAEUGS": "declaration"`
  - after: `"TKEBG/HRAEUGS": "declaration"`