### PR TITLE
Change `dict.json` output for `SHRA*EUGS` to "legislation"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -531,6 +531,7 @@
 "SEUT/S*EP": "citizen",
 "SHAU/TPER": "chauffer",
 "SHO/TKPWREP": "Sjogren",
+"SHRA*EUGS": "insulation",
 "SHREPD": "slept",
 "SKAOUS/EUF": "exclusive",
 "SKAOUS/EUFL": "exclusively",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -88420,7 +88420,7 @@
 "SHRA*EUBG": "EyeLasik",
 "SHRA*EUF": "legislative",
 "SHRA*EUF/REU": "slavery",
-"SHRA*EUGS": "insulation",
+"SHRA*EUGS": "legislation",
 "SHRA*EUGT": "legislate",
 "SHRA*EUR": "legislature",
 "SHRA*EURBGS": "ventricular fibrillation",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4349,7 +4349,7 @@
 "RE/HREF": "relieve",
 "EUPB/TEPBGS/-S": "intentions",
 "UPB/SKWRUFT": "unjust",
-"HREGT/SHUPB": "legislation",
+"SHRA*EUGS": "legislation",
 "PROPBL": "project",
 "THRERBLD": "threshold",
 "PHERTS": "merits",


### PR DESCRIPTION
Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s output for the `SHRA*EUGS` outline is now "legislation", and not "insulation".

Therefore, this PR proposes to fix this issue, and have the Gutenberg dictionary use `SHRA*EUGS` for "legislation".

If `SHRA*EUGS` isn't desired so much in Typey Type since it's asterisked, then I would propose `HREGT/SHRAEUGS` to be a better match for "legislation" than the current `HREGT/SHUPB`.