### PR TITLE
Add Plover `TPA*BG` outline for "faculty"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -121992,6 +121992,7 @@
 "TP/U/HRAEUBG": "if you like",
 "TPA": "fa",
 "TPA*": "pho",
+"TPA*BG": "faculty",
 "TPA*BGS": "faction",
 "TPA*D": "FDA",
 "TPA*EFD": "fatty acid",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4479,7 +4479,7 @@
 "PWOD/HREU": "bodily",
 "TPHOEG/-S": "notions",
 "OL/EUFR": "Oliver",
-"TPABG/UT": "faculty",
+"TPA*BG": "faculty",
 "KAPB/TPHOPB": "cannon",
 "THRAOEPB": "thirteen",
 "SAEULG": "sailing",


### PR DESCRIPTION
Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) has a `TPA*BG` outline for "faculty", so this PR proposes to add it to `dict.json`, and use it as the "faculty" outline in the Gutenberg dictionary.