### PR TITLE
Mark `HOL/TKEU` and `HOL/TKEU/TKAEU` outlines for "holiday" as mis-strokes

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -244,6 +244,8 @@
 "HEPBLDZ": "hedged",
 "HEUPLT": "limit",
 "HEURT": "liter",
+"HOL/TKEU": "holiday",
+"HOL/TKEU/TKAEU": "holiday",
 "HOPB/ORBL": "honorable",
 "HOUD/*ER": "louder",
 "HRAEUD/EUS/AE": "lady's",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -24211,8 +24211,6 @@
 "HOL/TKAEUFPLT": "holiday{.}",
 "HOL/TKAEUS": "holidays",
 "HOL/TKER": "holder",
-"HOL/TKEU": "holiday",
-"HOL/TKEU/TKAEU": "holiday",
 "HOL/TKPWRAF": "holograph",
 "HOL/TKPWRAF/EUBG": "holographic",
 "HOL/TKPWRAFBG": "holographic",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4709,7 +4709,7 @@
 "TPAOEUL/TPHA*EUPL": "filename",
 "TR-FTS": "artists",
 "PWHRAOPL": "bloom",
-"HOL/TKEU": "holiday",
+"HOL/TKAEU": "holiday",
 "PWRAOUT": "brute",
 "RAO*EP": "repair",
 "TPEUFT": "fist",


### PR DESCRIPTION
The following outlines for "holiday" seem like mis-strokes to me:

- `HOL/TKEU` ("holdi")
- `HOL/TKEU/TKAEU` ("holdiday")

So, this PR proposes to move them to `bad-habits.json`, and have `HOL/TKAEU` with the long "ā" vowel be considered the more accurate pronunciation in the Gutenberg dictionary.