### PR TITLE
Mark `PORT/TKWAOES` outline for "Portuguese" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -440,6 +440,7 @@
 "PHULT/SRAO*EUB": "multivitamin",
 "POEP/-LS": "hopeless",
 "POEUPBT/PWHRAPBG": "pointblank",
+"PORT/TKWAOES": "Portuguese",
 "POS/TO*PB": "Boston",
 "POUPBZ": "pounds",
 "PR*RD": "{.}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -62919,7 +62919,6 @@
 "PORT/TKPWAL": "Portugal",
 "PORT/TKPWAOES": "Portuguese",
 "PORT/TKPWAOEZ": "Portuguese",
-"PORT/TKWAOES": "Portuguese",
 "PORT/TOE": "porteau",
 "PORT/TPHER": "partner",
 "PORT/TPHOE/SROE": "Porto Novo",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4747,7 +4747,7 @@
 "PHARBL": "marshal",
 "RAOULD": "ruled",
 "TPAOERS/HREU": "fiercely",
-"PORT/TKWAOES": "Portuguese",
+"PORT/TKPWAOES": "Portuguese",
 "KOFT/AOUPL": "costume",
 "PEUT": "pit",
 "TKORD": "disorder",


### PR DESCRIPTION
It looks like the `PORT/TKWAOES` outline for "Portuguese" is missing the `P` stroke in the `TKPW` "g" sound.

So, this PR proposes to consider it a mis-stroke, and have the Gutenberg dictionary use `PORT/TKPWAOES`.