### PR TITLE
Add Plover single-stroke `HRARBT` outline for "elaborate"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -26788,6 +26788,7 @@
 "HRARBG/SERT": "Lacrisert",
 "HRARBG/SERTS": "Lacriserts",
 "HRARBS": "lashes",
+"HRARBT": "elaborate",
 "HRARD": "lard",
 "HRARDZ": "Atlantic Yards",
 "HRARG/SKWRO": "largo",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4775,7 +4775,7 @@
 "TPAOEGT": "fitting",
 "PWOPBDZ": "bonds",
 "EUPB/STRUBGD": "instructed",
-"HRAEB/RAT": "elaborate",
+"HRARBT": "elaborate",
 "KORPS": "corpse",
 "PWE/WEULD/ERD": "bewildered",
 "ES/EPBS": "essence",


### PR DESCRIPTION
This PR proposes to add Plover [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s single-stroke `HRARBT` outline for "elaborate", and have the Gutenberg dictionary use it.