### PR TITLE
Mark `SA/RA` outline for "Sarah" as a mis-stroke as it outputs "Sara".

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -520,6 +520,7 @@
 "ROEB/TUS/*EUP": "Robitussin",
 "S*EURT/PHAO*EUPB": "erythromycin",
 "S*EURT/PHAOEUS/*EUB": "erythromycin",
+"SA/RA": "Sarah",
 "SAL/SRAUGS": "salvation",
 "SAO*EUD/A*L": "{^cidal}",
 "SAOER/KWRUS": "serious",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -81819,7 +81819,7 @@
 "SA/PWEU/TPHA": "Sabina",
 "SA/PWRAOE/TPHA": "Sabrina",
 "SA/PWREU/TPHA": "Sabrina",
-"SA/RA": "Sarah",
+"SA/RA": "Sara",
 "SA/RA/TKRAS/TPHER": "Sarah Drasner",
 "SA/RA/TOE/TKPWA": "Saratoga",
 "SA/RAFP/KHEU": "sriracha",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4847,7 +4847,7 @@
 "TPAS/EULT": "facility",
 "PRA*EUFD": "praised",
 "WARPB/TEU/-S": "warranties",
-"SA/RA": "Sarah",
+"SAEU/RA": "Sarah",
 "HAP/KWRER": "happier",
 "KAEUGT": "indicating",
 "ROB": "rob",


### PR DESCRIPTION
Plover [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) outputs "Sara", without an "h", for the `SA/RA` outline.

So, this PR proposes to fix the current `SA/RA` entry, and have the Gutenberg dictionary use `SAEU/RA` for "Sarah".

The other Plover outline for "Sarah", `SAEUR/KWRA`, reads a bit weird to me ("Saryah"?), so I'd also be happy to mark that as a mis-stroke, but I'm not sure if I'm just not aware of a steno rule.