### PR TITLE
Add `THAPBG/-FL` condensed stroke for "thankful"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1237,6 +1237,7 @@
 "TH/WUPB": "this one",
 "THA/WUPB": "that one",
 "THAPB/K-FL/-PBS": "thankfulness",
+"THAPBG/-FL": "thankful",
 "THE/R": "they are",
 "THE/S-R": "they have",
 "THEURD/HREU": "thirdly",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5011,7 +5011,7 @@
 "SHOUTS": "shouts",
 "SO/H-PB/KAULD": "so-called",
 "THAOEPL": "theme",
-"THAPB/K-FL": "thankful",
+"THAPBG/-FL": "thankful",
 "AD/PHEUGS": "admission",
 "SPWR-S": "enters",
 "EL/SRAEUTD": "elevated",


### PR DESCRIPTION
Plover [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) has a `THA*PBG/-FL` outline for "thankful", but for some reason it doesn't have a `THAPBG/-FL` outline, which outputs "thankful" as expected.

So, this PR proposes to add it as a condensed stroke and have the Gutenberg dictionary use it due to, in at least my opinion, "thank-ful" being a better word division than "than-kful".