### PR TITLE
Change outline used in Gutenberg for "triumphant" to have long "ī" vowel sound

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5043,7 +5043,7 @@
 "PRAOEFP": "preach",
 "EBGS/SAOED/-G": "exceeding",
 "REUPBG/-G": "ringing",
-"TREU/UPL/TPAPBT": "triumphant",
+"TRAOEU/UPL/TPAPBT": "triumphant",
 "TKE/TPAOEUPBS": "defiance",
 "ER/APBD": "errand",
 "WOEBG": "woke",


### PR DESCRIPTION
This PR proposes to change the outline used in Gutenberg for "triumphant" to have a long "ī" vowel sound. I don't think any English pronunciations of "triumphant" use a short "i".