### PR TITLE
Change outline for "Satan" to have a long "ā" vowel

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -527,6 +527,7 @@
 "SAOER/KWRUS/TPHES": "seriousness",
 "SAOEULG/SPORB": "cyclosporin",
 "SAOUPS": "{super^}",
+"SAT/APB": "Satan",
 "SAUP": "SAUB sub^ misstroke",
 "SEFB/APBT": "servant",
 "SELGD": "secondly",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -84258,7 +84258,6 @@
 "SAT": "sat",
 "SAT/*EUR": "satyr",
 "SAT/AOEUR": "satire",
-"SAT/APB": "Satan",
 "SAT/EL/HRAOEUT": "satellite",
 "SAT/HRAOEUT": "satellite",
 "SAT/HRAOEUT/-S": "satellites",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5088,7 +5088,7 @@
 "WARPL/HREU": "warmly",
 "SAL/REU": "salary",
 "T-PBS": "continuous",
-"SAT/APB": "Satan",
+"SAEUT/APB": "Satan",
 "T-PB/WAL": "continual",
 "TKAOE/TPEPBD/-D": "defended",
 "PWRAEBGS": "breaks",


### PR DESCRIPTION
This PR proposes to change outline for "Satan" to have a long "ā" vowel, and mark the outline with a short "a" vowel as a mis-stroke 🤘