### PR TITLE
Mark `KA/TAOED/RAL` outline for "cathedral" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -270,6 +270,7 @@
 "HULG": "hulk",
 "HUPBD/SKWRU": "Hindu",
 "K-FRPL/TEU": "conformity",
+"KA/TAOED/RAL": "cathedral",
 "KAFT/AOEURP": "cast-iron",
 "KALS/TOEPB/*EUP": "calcitonin",
 "KAO*ERP": "{^keeper}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -30099,7 +30099,6 @@
 "KA/TA/TOPB/EUBG": "catatonic",
 "KA/TAEUFP/*EUPB": "catechin",
 "KA/TAL/SEUS": "catalysis",
-"KA/TAOED/RAL": "cathedral",
 "KA/TAR": "Qatar",
 "KA/TAR/SEUS": "catharsis",
 "KA/TAS/TRO/TPAOE": "catastrophe",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5184,7 +5184,7 @@
 "EUPB/SRAOEUT": "invite",
 "A/SKWROEUPBG": "adjoining",
 "TKUFBG": "dusk",
-"KA/TAOED/RAL": "cathedral",
+"KA/THAOED/RAL": "cathedral",
 "TRAO*UT/-S": "truths",
 "PHRAEUG": "plague",
 "SAPB/TKEU": "sandy",


### PR DESCRIPTION
This PR proposes to mark `KA/TAOED/RAL` outline for "cathedral" as a mis-stroke due to missing an `H`, and prefer `KA/THAOED/RAL` in the Gutenberg dictionary.