### PR TITLE
Mark `SREFT/SRAL` outline for "festival" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -596,6 +596,7 @@
 "SRALT": "vault",
 "SRAPBG/PHAOEUS/*EUB": "vancomycin",
 "SRAUTS": "vaults",
+"SREFT/SRAL": "festival",
 "SREURPBLG/*EUB": "virgin",
 "SROL/TKPWAR": "vulgar",
 "SROUBD/-D": "surrounded",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -98036,7 +98036,6 @@
 "SREFT/PWHREU": "vestibuli",
 "SREFT/PWHRO": "{vestibulo^}",
 "SREFT/REU": "vestry",
-"SREFT/SRAL": "festival",
 "SREGS": "investigation",
 "SREGS/-S": "investigations",
 "SREGT": "investigate",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5456,7 +5456,7 @@
 "STPHAFPD": "snatched",
 "SHAFT": "shaft",
 "HR*EUPBGD": "linked",
-"SREFT/SRAL": "festival",
+"TPEFT/SRAL": "festival",
 "SKHRAOUFL": "exclusively",
 "SKWROEF": "Jove",
 "WEUBGD/-PBS": "wickedness",


### PR DESCRIPTION
This PR proposes to mark the `SREFT/SRAL` outline for "festival" as a mis-stroke due to beginning with an `SR` "v" sound, and prefer the `TPEFT/SRAL` outline in the Gutenberg
dictionary.