### PR TITLE
Add Plover's `STPEUBG` outline for "fantastic"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -101926,6 +101926,7 @@
 "STPERL": "sterile",
 "STPES/TPEUS/TEU": "specificity",
 "STPEU": "{^i}",
+"STPEUBG": "fantastic",
 "STPEUBG/PHO/PHAPB/OPL/TER": "sphygmomanometer",
 "STPEUBGS": "sphinx",
 "STPEUF/KAEUT/-D": "sophisticated",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5414,7 +5414,7 @@
 "ORPB/*PLT": "ornament",
 "SHRAO*U": "slew",
 "STAOURD": "steward",
-"TPAPB/T-FBG": "fantastic",
+"STPEUBG": "fantastic",
 "EFGS": "evolution",
 "PAEURBT/HREU": "patiently",
 "R*EFRS": "reverse",


### PR DESCRIPTION
This PR proposes to add Plover [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s `STPEUBG` outline for "fantastic", and have the Gutenberg dictionary use it.