### PR TITLE
Add fingerspelling entry for lowercase "madam"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -400,6 +400,7 @@
 "PH-PBLG/TPHAEUGS": "imagination",
 "PH-PT": "Manhattan",
 "PHA*EUBG/-G": "{^making}",
+"PHAD/APL": "madam",
 "PHAEZ/-Z": "phases",
 "PHAFRP/-G": "marching",
 "PHAO*EUFG": "{^imizing}",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -697,6 +697,7 @@
 "PH*/A*/KWR*/O*/R*/A*/HR*/T*/KWR*": "mayoralty",
 "PH*/A*/R*/*E": "mare",
 "PH*/A*/R*/*EU/*U/S*": "Marius",
+"PH*/A*/TK*/A*/PH*": "madam",
 "PH*EULD/H-PB/AEUGD": "middle-aged",
 "PH*EULG/TK-LS/PHAEUD": "milkmaid",
 "PH*P/*E/R*/KWR*/T*/O*/TPH*": "Meryton",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -53912,7 +53912,7 @@
 "PHAD/-PBD": "maddened",
 "PHAD/-PBG": "maddening",
 "PHAD/-PBS": "madness",
-"PHAD/APL": "madam",
+"PHAD/APL": "Madam",
 "PHAD/APL/PWUT/*ER/TPHRAOEU": "Madam Butterfly",
 "PHAD/ER": "madder",
 "PHAD/HREUPB": "Madeleine",

--- a/dictionaries/proper-nouns.json
+++ b/dictionaries/proper-nouns.json
@@ -112,7 +112,6 @@
 "KWROURPB": "your Honor",
 "HO*PB/RABL": "Honorable",
 "HO*UPB/RABL": "Honourable",
-"PHAD/APL": "madam",
 "PHA*D/APL": "Madam",
 "PHAEUD": "maid",
 "PHAFRT": "master",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3891,7 +3891,7 @@
 "SKWROEUPBT": "joint",
 "REFR": "refer",
 "EBGS/PEG": "expecting",
-"PHAD/APL": "madam",
+"PH*/A*/TK*/A*/PH*": "madam",
 "R-RD": "railroad",
 "S*/P*/A*/K*/*E": "spake",
 "R-PG": "respecting",


### PR DESCRIPTION
Due to outline `PHAD/APL` outputting uppercase "Madam" in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), it seems like there is no outline option for lowercase "madam". 

So, in order to keep current lowercase "madam" entries, change the outlines to "madam"'s fingerspelling.

Closes #317.