### PR TITLE
Add "TPRAOUT/-LS": "fruitless" condensed stroke.

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1486,6 +1486,7 @@
 "TPOURT/H-PB/TPEUF": "forty-five",
 "TPRA*PBG/EURB": "Frankish",
 "TPRAOEUT/-FL/HREU": "frightfully",
+"TPRAOUT/-LS": "fruitless",
 "TPRAPBG/-PBS": "frankness",
 "TPRAPBG/HREU": "frankly",
 "TPREPBD/-LS": "friendless",


### PR DESCRIPTION
This PR only proposes to add `"TPRAOUT/-LS": "fruitless"` as a condensed stroke. It's not necessarily better than `"TPRAOUT/HRES": "fruitless"`, the current outline used in Gutenberg, and so no change is proposed there.

Closes #294.