### PR TITLE
Add `KAPT/-S` condensed stroke for "captains"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -435,6 +435,7 @@
 "KAOL/EFT": "coolest",
 "KAPB/PEU/-S": "canopies",
 "KAPLS": "cams",
+"KAPT/-S": "captains",
 "KAR/HRAOD/-D": "car loaded",
 "KARBG/AOEUZ/-D": "characterized",
 "KAU/P*/P*/*EUS": "coppice",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5887,7 +5887,7 @@
 "HEPBLG": "hedge",
 "K*": "k",
 "SKWRUBGS": "jurisdiction",
-"KAPT/EUPBS": "captains",
+"KAPT/-S": "captains",
 "SET/HRER/-S": "settlers",
 "TKPWAEUPBG": "gaining",
 "SRAL/KWRAPBT": "valiant",


### PR DESCRIPTION
Although Plover's outline for "captains" is `KAPT/EUPBS`, since stroking just `KAPT` outputs "captain", this PR proposes to add a condensed stroke that just adds `-S` to that, and use it in the Gutenberg dictionary, rather than "captain-ins".