### PR TITLE
Mark `APBGT/WAER` outline for "sanctuary" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -96,6 +96,7 @@
 "APB/TAOEU": "{anti^}",
 "APB/TEU": "{anti^}",
 "APB/TUBG/TEU": "antiquity",
+"APBGT/WAER": "sanctuary",
 "APBL/REU/HREU": "angrily",
 "APBS/-BL": "answerable",
 "APBS/-D": "answered",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -10269,7 +10269,6 @@
 "APBGS/KWRO/HREUT/EUBG": "anxiolytic",
 "APBGS/OUS": "anxious",
 "APBGS/TROPL": "angstrom",
-"APBGT/WAER": "sanctuary",
 "APBL/*EUS": "analyst",
 "APBL/-S": "annals",
 "APBL/AEUS": "analysis",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6636,7 +6636,7 @@
 "POFRP": "pomp",
 "PHES": "mess",
 "PRABGS/A*U": "practise",
-"APBGT/WAER": "sanctuary",
+"SAPBGT/WAER": "sanctuary",
 "SAOUP/STEURBS": "superstitious",
 "KAEFL": "casual",
 "WO*EU": "Iowa",


### PR DESCRIPTION
This PR proposes to mark `APBGT/WAER` outline for "sanctuary" as a mis-stroke due to missing `S` at the beginning (it's the only outline in the set for "sanctuary" that is missing it). It also proposes to prefer `SAPBGT/WAER` in the Gutenberg dictionary.