### PR TITLE
Change Gutenberg dictionary outline for "catastrophe" to `KATS/TROEF`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6710,7 +6710,7 @@
 "SOB/-G": "sobbing",
 "PHOPB/OT/TPHUS": "monotonous",
 "SPHROEGS": "explosion",
-"KATS/TROER": "catastrophe",
+"KATS/TROEF": "catastrophe",
 "R-PT/TPHREU": "respectfully",
 "W*/*E/A*/R*/*EU/*E/TK*": "wearied",
 "KATS": "cats",


### PR DESCRIPTION
This PR proposes to just change Gutenberg dictionary outline for "catastrophe" to prefer `KATS/TROEF` over the current `KATS/TROER`. I think the "f" sound in "catastrophe" is a more prominent sound than its "r" in helping to remember the outline.