### PR TITLE
Add Plover `STREUFBG` outline for "asterisk"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -103035,6 +103035,7 @@
 "STREUF/-D": "strived",
 "STREUF/-G": "striving",
 "STREUF/-S": "strives",
+"STREUFBG": "asterisk",
 "STREUFS": "strives",
 "STREUL": "industrial",
 "STREUL/A*EUGS": "industrialization",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7252,7 +7252,7 @@
 "TOEFT": "toast",
 "TKRED/-FL/KWREU": "dreadfully",
 "SKWRUD/*EUT": "Judith",
-"AS/TREUS": "asterisk",
+"STREUFBG": "asterisk",
 "SREUR/SKWREUL": "Virgil",
 "ED/TPEUS": "edifice",
 "SWELD": "swelled",


### PR DESCRIPTION
This PR proposes to add the Plover single-stroke `STREUFBG` outline for "asterisk" to `dict.json`, and have the Gutenberg dictionary prefer it over `AS/TREUS`.