### PR TITLE
Change vowel sound in Gutenberg outline for "handwriting" to long "ī"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7265,7 +7265,7 @@
 "SHREUPL": "slim",
 "WHEUS/-LG": "whistling",
 "SEUL/-BL": "syllable",
-"HAPBD/WREUG": "handwriting",
+"HAPBD/WRAOEUG": "handwriting",
 "KPHEUGS/ERS": "commissioners",
 "HRAOEUPL": "lime",
 "SPUR": "spur",


### PR DESCRIPTION
This PR proposes to change the Gutenberg outline for "handwriting" to have a long "ī" vowel sound as I think this is more intuitive than the short "i" vowel. I don't necessarily think the short "i" is a mis-stroke, so there's no proposal to move it to `bad-habits.json`.