### PR TITLE
Add `HEUFT/KWRAPBS` condensed stroke for "historians"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -449,6 +449,7 @@
 "PHAUPB": "TPHAUPB non- misstroke",
 "PHERPLT": "ferment",
 "PHEUBS": "minutes",
+"PHEUFT/KWRAPBS": "historians",
 "PHEUFT/ROUS": "mysterious",
 "PHEUFT/RUS": "mysterious",
 "PHEUFT/WOUS": "mysterious",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -355,6 +355,7 @@
 "HERLD/EUBG": "heraldic",
 "HERPLT/APBLG": "hermitage",
 "HEUD/KWROUS/HREU": "hideously",
+"HEUFT/KWRAPBS": "historians",
 "HOEFTD": "hosted",
 "HOEL/-D": "holed",
 "HOEUL/-PBS": "holiness",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -57914,7 +57914,6 @@
 "PHEUFT/AOER/KWRUS": "mysterious",
 "PHEUFT/EUBG": "mystic",
 "PHEUFT/K-L": "mystical",
-"PHEUFT/KWRAPBS": "historians",
 "PHEUFT/KWROUS": "mysterious",
 "PHEUFT/KWROUS/HREU": "mysteriously",
 "PHEUFT/KWRUS": "mysterious",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7311,7 +7311,7 @@
 "POURLS": "powerless",
 "PAEPBG": "passenger",
 "KRUFT": "crust",
-"PHEUFT/KWRAPBS": "historians",
+"HEUFT/KWRAPBS": "historians",
 "TKEUS/KHRAEUPL": "disclaim",
 "TPHOR/WAEU": "Norway",
 "PEBG/AOUL/AERTS": "peculiarities",


### PR DESCRIPTION
In Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), the only outline for "historians" specified is `PHEUFT/KWRAPBS`. I find this a bit strange since:

- I'm not sure where the `P` prefix comes from
- There is a valid outline for `"HEUFT/KWRAPB": "historian"`

Stroking `HEUFT/KWRAPBS` outputs "historians" as expected, so this PR proposes to:

- Add `"HEUFT/KWRAPBS": "historians"` as a condensed
- Mark current `"PHEUFT/KWRAPBS": "historians"` outline as a mis-stroke
- Change the Gutenberg dictionary to use `"HEUFT/KWRAPBS": "historians"`