### PR TITLE
Remove `SPEPBD/TAOURS` condensed stroke for "expenditures"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1152,7 +1152,6 @@
 "SPAOERZ": "spears",
 "SPAOPB/-FL": "spoonful",
 "SPAPBG/*LD": "spangled",
-"SPEPBD/TAOURS": "expenditures",
 "SPEURT/-LS": "spiritless",
 "SPHAOEULG/HREU": "smilingly",
 "SPHROR/*ER": "explorer",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7361,7 +7361,7 @@
 "SPOEULS": "spoils",
 "H*EPLT": "helmet",
 "KO*PBS/TPHAEUGS": "consternation",
-"SPEPBD/TAOURS": "expenditures",
+"EBGS/PEPBD/KHURS": "expenditures",
 "EUPL/POES": "impose",
 "ORPBLG/TPHAEU/TOR": "originator",
 "PA": "Pa",


### PR DESCRIPTION
This PR proposes to remove the `SPEPBD/TAOURS` condensed stroke for "expenditures", as it outputs "spend tours" in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33).

The Plover `EBGS/PEPBD/KHURS` outline sounds like the "most correct" outline for "expenditures" to me, so use that in the Gutenberg dictionary instead.