### PR TITLE
Change vowel sound in outline for "potent" to long "ō" in Gutenberg

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7394,7 +7394,7 @@
 "KA*FL": "calf",
 "PHAPB/WAL": "manual",
 "TKEUS/TURBG": "disturbing",
-"PO/TEPBT": "potent",
+"POE/TEPBT": "potent",
 "SPAEUGS": "anticipation",
 "PHELT": "melt",
 "TEUL/TKE": "tilde",


### PR DESCRIPTION
This PR proposes to change the vowel sound in outline for "potent" to a long "ō" in the Gutenberg dictionary.

Following on from [this comment](https://github.com/didoesdigital/steno-dictionaries/pull/340#issuecomment-616036605), I'm refraining from also proposing to make `PO/TEPBT` a mis-stroke :)