### PR TITLE
Prefer the `HRES/HREU` outline for "Leslie"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7921,7 +7921,7 @@
 "KHAOET": "cheat",
 "TKUB/HREU": "doubly",
 "TPHAD/KWAT": "inadequate",
-"HREZ/HREU": "Leslie",
+"HRES/HREU": "Leslie",
 "PWRES/*T": "blest",
 "TPAUR/PWAER": "forbear",
 "HAUPBT": "haunt",


### PR DESCRIPTION
This PR simply proposes to prefer the `HRES/HREU` outline for "Leslie" in the Gutenberg dictionary to avoid a (subjectively unnecessary) reach for the `Z` key.