### PR TITLE
Add `SREUFD/HREU` outline as a condensed stroke for "vividly"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1181,6 +1181,7 @@
 "SREBGS/-S": "vexes",
 "SREBGS/S*E": "vexes",
 "SREFT/-PLTS": "vestments",
+"SREUFD/HREU": "vividly",
 "SREURT/WOS/TEU": "virtuosity",
 "SREURT/WOUS": "virtuous",
 "SROUFP/SAEUF/-D": "vouchsafed",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7901,7 +7901,7 @@
 "HOFT/EULTS": "hostilities",
 "TKPWAEUT": "gait",
 "T-L": "it'll",
-"SREUF/TKHREU": "vividly",
+"SREUFD/HREU": "vividly",
 "STRUBGT": "instruct",
 "TKEUBG/*EPB/-S": "Dickens",
 "PAOUR/TAPB": "puritan",


### PR DESCRIPTION
This PR proposes to add `SREUFD/HREU` outline as a condensed stroke for "vividly" and have the Gutenberg dictionary prefer it over the current Plover `SREUF/TKHREU`.

I think it makes a more logical division of the word ("vivid-ly" vs "viv-dly"), and also makes a nice construction from current outlines and suffixes (`SREUFD` for "vivid", `HREU` for "{^ly}").