### PR TITLE
Add Plover `TKOPLT` outline for "dominant"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -115684,6 +115684,7 @@
 "TKOPL/TPHOE/-S": "dominoes",
 "TKOPL/TPHOE/AES/PEUZ": "Domino's Pizza",
 "TKOPL/TPHUS": "dominus",
+"TKOPLT": "dominant",
 "TKOPT": "adopt",
 "TKOPT/-BL": "adoptable",
 "TKOPT/TAOE": "adoptee",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8074,7 +8074,7 @@
 "RAOEUDZ": "rides",
 "SPAOPB": "spoon",
 "EUPL/TPHEPBT": "imminent",
-"TKOPL/TPHAT": "dominant",
+"TKOPLT": "dominant",
 "HRAOERP": "leadership",
 "PEUFRPB": "pinch",
 "WAOER/HREU": "wearily",


### PR DESCRIPTION
This PR proposes to add Plover's `TKOPLT` outline for "dominant" and use it in the Gutenberg dictionary.