### PR TITLE
Use outline with "e" vowel (`SRE/RAPB/TKA`) for veranda in Gutenberg dictionary

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8210,7 +8210,7 @@
 "TREUT": "transmit",
 "STKPAFP": "dispatch",
 "OEPBT": "onto",
-"SRA/RAPB/TKA": "veranda",
+"SRE/RAPB/TKA": "veranda",
 "TKEUP": "dip",
 "EUPB/SPHREUBG/-BL": "inexplicable",
 "HRAOEUR": "liar",


### PR DESCRIPTION
I wouldn't consider the `SRA/RAPB/TKA` outline for "veranda" a mis-stroke, but I think `SRE/RAPB/TKA` is _more_ correct, so this PR proposes to use it in the Gutenberg dictionary.