### PR TITLE
Change outline used for "poisonous" in Gutenberg to use an `S` over `Z`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8275,7 +8275,7 @@
 "UPBD/TKPW": "undergo",
 "HA*ER": "hare",
 "HAEUZ": "haze",
-"POEUZ/TPHOUS": "poisonous",
+"POEUS/TPHOUS": "poisonous",
 "OEPLT": "omit",
 "PWE/WAEUR": "beware",
 "STKPWAS/TEU": "sagacity",


### PR DESCRIPTION
This PR proposes an ergonomic change to use `POEUS/TPHOUS` over `POEUZ/TPHOUS` in the Gutenberg dictionary. I think that both outlines are as correct as each other, but if one can prevent a reach to `Z`, then that's the one I would at least prefer.