### PR TITLE
Change outline for "methinks" in dictionaries to be `PHE/TK-LS/THEUS`

### DIFF
--- a/dictionaries/nouns.json
+++ b/dictionaries/nouns.json
@@ -123,7 +123,7 @@
 "KORT/KWRERS": "courtiers",
 "SEUL/SRER/KWREU": "silvery",
 "PHAOEUT/SKWREU/HREU": "mightily",
-"PHE/THEUS": "methinks",
+"PHE/TK-LS/THEUS": "methinks",
 "TKAEUR/SAEU": "daresay",
 "HAS/TPH*": "hasn",
 "WA/TPH*": "wasn",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8407,7 +8407,7 @@
 "RABG": "rack",
 "EUPB/KPREPBS/-BL": "incomprehensible",
 "APBT/AG/TPHEUFT": "antagonist",
-"PHE/THEUS": "methinks",
+"PHE/TK-LS/THEUS": "methinks",
 "PWAR/HREU": "barley",
 "PHRA/TOE": "plateau",
 "SUPT": "superintendent",


### PR DESCRIPTION
Plover currently does not have an "official" outline for "methinks", and the original `PHE/THEUS` outline outputs "me thinks" with a space. So, this PR proposes to change it to `PHE/TK-LS/THEUS` to ensure that "me" and "thinks" stick together. I couldn't figure out any better outline, but I'm more than happy to change it to something else!