### PR TITLE
Mark `KUFD/TEU` outline for "custody" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -373,6 +373,7 @@
 "KRERBG": "correct",
 "KRO": "{co-^}",
 "KUB/PWAORD": "cupboard",
+"KUFD/TEU": "custody",
 "KUP/PWORD": "cupboard",
 "KUP/PWORDZ": "cupboards",
 "KUPB/SEUL": "council",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -42751,7 +42751,6 @@
 "KUF/HR*EUPBG": "cufflink",
 "KUF/PHER": "customer",
 "KUFD": "cuffed",
-"KUFD/TEU": "custody",
 "KUFP": "cusp",
 "KUFP/EUD": "cuspid",
 "KUFPL": "custom",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8667,7 +8667,7 @@
 "KWOGS": "quotation",
 "TPUL/EFT": "fullest",
 "EBGS/POGS": "exposition",
-"KUFD/TEU": "custody",
+"KUFT/TKEU": "custody",
 "THERPLT": "thermometer",
 "PHRAUBL": "plausible",
 "TOS": "toss",


### PR DESCRIPTION
This PR proposes to mark the "custody" outline `KUFD/TEU` ("cusdoty") as a mis-stroke, and instead prefer the Plover `KUFT/TKEU` outline as being more accurate.