### PR TITLE
Prefer `PER/SPRAEUGS` outline for "perspiration" in the Gutenberg dictionary

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8708,7 +8708,7 @@
 "PHEG": "Meg",
 "PHURD/ROUS": "murderous",
 "SR*EPBT": "serenity",
-"PERP/RAEUGS": "perspiration",
+"PER/SPRAEUGS": "perspiration",
 "KOFRPB/TREU": "coventry",
 "*EUPL/TKEPBT": "impudent",
 "AR/TKOR": "ardor",


### PR DESCRIPTION
This PR proposes to prefer the `PER/SPRAEUGS` outline for "perspiration" in the Gutenberg dictionary over `PERP/RAEUGS` ("per-sprātion" vs "perp-rātion").

I don't necessarily think `PERP/RAEUGS` looks wrong, so there is no current intention to mark it as a mis-stroke. 