### PR TITLE
Prefer the explicit addition of ending `A` stroke for "Cleopatra" (`KHRAOE/PAT/RA`)

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8748,7 +8748,7 @@
 "WEUS/KEU": "whiskey",
 "RE/TEUFL": "relatively",
 "TPORBD/-G": "forbidding",
-"KHRAOE/PAT/R": "Cleopatra",
+"KHRAOE/PAT/RA": "Cleopatra",
 "WEUL/HROE": "willow",
 "PHAT/PHAT/K-L": "mathematical",
 "SO/SKWRURPB": "sojourn",


### PR DESCRIPTION
This PR proposes to prefer the explicit addition of an ending `A` stroke for the "Cleopatra" outline in the Gutenberg dictionary (`KHRAOE/PAT/RA`).