### PR TITLE
Prefer stressed long "i" over short "o" vowel in outline for "biography" (`PWAOEUG/TPEU`)

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8777,7 +8777,7 @@
 "TKPWHRAOE": "glee",
 "TKULT": "adult",
 "SOL/AS": "solace",
-"PWOG/TPEU": "biography",
+"PWAOEUG/TPEU": "biography",
 "TP*/TP*/TP-PL": "ff.",
 "HARD/SH-P": "hardship",
 "HRAOEUD": "lied",


### PR DESCRIPTION
This PR proposes to prefer the stressed long "ī" over short "o" vowel in outline for "biography".

I think "bīg-fi" sounds closer in pronunciation to "biography" than "bog-fi", but I don't necessarily think `PWOG/TPEU` reads as a mis-stroke, so the PR only proposes to change the Gutenberg entry.