### PR TITLE
Prefer long "ō" vowel in outline for "omen" in the Gutenberg dictionary

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9006,7 +9006,7 @@
 "TKEUL/SKWREPBT": "diligent",
 "HEUPB/TKAOU": "Hindu",
 "PWHRUPBT": "blunt",
-"O/PHEPB": "omen",
+"OE/PHEPB": "omen",
 "PWHRAEBG": "bleak",
 "SRAOEPLT/HREU": "vehemently",
 "WREFPD/-PBS": "wretchedness",


### PR DESCRIPTION
Similar to "Owen" in #340, this PR proposes to change the outline for "omen" in the Gutenberg dictionary to have a long "ō" vowel (without marking the short vowel version as a mis-stroke).