### PR TITLE
Add Plover `SROEBGS` outline for "vocation"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -99238,6 +99238,7 @@
 "SROEBG/PWAER": "vocabulary",
 "SROEBG/PWHRAER": "vocabulary",
 "SROEBG/PWRAER": "vocabulary",
+"SROEBGS": "vocation",
 "SROEBGS/PHA*PB": "Boltzmann",
 "SROEBGS/WAG/*EPB": "Volkswagen",
 "SROEBGS/WAG/-PB": "Volkswagen",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9030,7 +9030,7 @@
 "ORPBS": "ordinance",
 "PWAPL/PWAO": "bamboo",
 "AFPS/TKAPL": "Amsterdam",
-"SRO/KAEUGS": "vocation",
+"SROEBGS": "vocation",
 "AD/PHAOEUR/ER": "admirer",
 "HREUFRP": "limp",
 "PAL/EUD": "pallid",


### PR DESCRIPTION
This PR proposes to add Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s `SROEBGS` outline for "vocation", and prefer it in the Gutenberg dictionary over `SRO/KAEUGS`.