### PR TITLE
Add `TKE/TPHOET` outline as a condensed stroke for "denote"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1291,6 +1291,7 @@
 "TKE/TEFT": "detest",
 "TKE/TEFT/-BL": "detestable",
 "TKE/TKPW*/HR*/SKWREU": "degli",
+"TKE/TPHOET": "denote",
 "TKE/TPHOPL/TPHAEUT/-D": "denominated",
 "TKEBG/*ER": "decker",
 "TKEFS/EUF": "defensive",


### PR DESCRIPTION
Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33) currently only has one outline for "denote", with a long "ē" vowel: `TKAOE/TPHOET`. This is not wrong at all, so this PR only proposes to add `TKE/TPHOET` outline as a condensed stroke for "denote". 