### PR TITLE
Prefer addition of explicit "l" (`HR`) stroke in outline for "vocabulary"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9101,7 +9101,7 @@
 "KREUFP": "crisp",
 "SKWRERBG": "jerk",
 "TOUT": "tout",
-"SROEBG/PWAER": "vocabulary",
+"SROEBG/PWHRAER": "vocabulary",
 "STROL": "stroll",
 "PAORL": "poorly",
 "KPOEFG": "composing",


### PR DESCRIPTION
This PR proposes to prefer addition of an explicit "l" (`HR`) stroke in outline for "vocabulary" in the Gutenberg dictionary. 

To me, `SROEBG/PWHRAER` ("vōc-blary") sounds closer to "vocabulary" than `SROEBG/PWAER` ("vōc-bary"), but I wouldn't go so far as to mark the latter as a mis-stroke.