### PR TITLE
Prefer `AUS/TAOER` outline for "austere"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9117,7 +9117,7 @@
 "PHEL/OE": "mellow",
 "TPHAT/ALT": "nationality",
 "SKWRAPL": "jam",
-"AU/STER": "austere",
+"AUS/TAOER": "austere",
 "SHAOTS": "shoots",
 "KAS/WAEL": "casually",
 "PEPB/SEUF": "pensive",


### PR DESCRIPTION
This PR proposes to prefer the long "ē" vowel and division of word syllables of the `AUS/TAOER` outline for "austere" in the Gutenberg dictionary, over the current `AU/STER` outline.