### PR TITLE
Prefer long "ē" vowel in outline for "albeit" (`AL/PWAOET`) in Gutenberg

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9212,7 +9212,7 @@
 "KEURBG": "Kirk",
 "PWO*U": "bough",
 "PHOEPLT/OUS": "momentous",
-"AL/PWAEUT": "albeit",
+"AL/PWAOET": "albeit",
 "EPB/HRARPBLG": "enlarge",
 "HARD/-PBS": "hardness",
 "SEUFL/AOEUZ/-D/A*U": "civilised",


### PR DESCRIPTION
This PR proposes to prefer a long "ē" vowel in outline for "albeit" in the Gutenberg dictionary.

I think `AL/PWAOET` ("al-bēt") sounds closer to "albeit" than `AL/PWAEUT` ("al-bait").