### PR TITLE
Change vowel sound in outline for "multiply" to long "ī" (`PHULT/PHRAOEU`)

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -477,6 +477,7 @@
 "PHRE/SEFRB": "preserve",
 "PHREUBGS/-S": "applications",
 "PHRO*EUPB": "PHAO*UPB immuno^ misstroke",
+"PHRULT/PHRAOEU": "multiply",
 "PHUBG/HRAR": "muscular",
 "PHUFPBG/HRAR": "muscular",
 "PHULT/SRAO*EUB": "multivitamin",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -61135,7 +61135,6 @@
 "PHRUGD": "plugged",
 "PHRUGS": "plugs",
 "PHRULS": "+=",
-"PHRULT/PHRAOEU": "multiply",
 "PHRUPB/*PBLG": "plunge",
 "PHRUPB/*PBLG/-D": "plunged",
 "PHRUPB/*PBLG/-S": "plunges",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9366,7 +9366,7 @@
 "PWAPB/EURB": "banish",
 "HREBG/K-L": "electrical",
 "ERB": "herb",
-"PHULT/PHREU": "multiply",
+"PHULT/PHRAOEU": "multiply",
 "PROS/PER": "prosper",
 "TPRAOEU/A*R": "friar",
 "TPHAOEUT/HREU": "nightly",


### PR DESCRIPTION
- Prefer long "i" vowel outline in Gutenberg dictionary (`PHULT/PHRAOEU`)
- Mark `PHRULT/PHRAOEU` outline for "multiply" as a mis-stroke due to extraneous `R` stroke in "mult"
