### PR TITLE
Mark `WHEURL/WEUPD` outline for "whirlwind" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -1046,6 +1046,7 @@
 "WAORD/WAUBG": "boardwalk",
 "WHAOELD": "withhold",
 "WHATS/TKPW-G/OB": "what's going on",
+"WHEURL/WEUPD": "whirlwind",
 "WO*RT/THEU": "worthy",
 "WOR/TH*EU": "worthy",
 "WOR/TH*EU/*ES": "worthiest",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -137867,7 +137867,6 @@
 "WHEURL/PAOL": "whirlpool",
 "WHEURL/WEUPBD": "whirlwind",
 "WHEURL/WEUPBDZ": "whirlwinds",
-"WHEURL/WEUPD": "whirlwind",
 "WHEUS/*BG": "whisk",
 "WHEUS/*BG/-S": "whisks",
 "WHEUS/*L": "whistle",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9918,7 +9918,7 @@
 "KWRAUPB/-G": "yawning",
 "PHUS/TARB": "mustache",
 "S*UPLT": "supplement",
-"WHEURL/WEUPD": "whirlwind",
+"WHEURL/WEUPBD": "whirlwind",
 "KHRARB": "clash",
 "T*ERPBS": "Terence",
 "HRAPLT/-BL": "lamentable",


### PR DESCRIPTION
This PR proposes to mark `WHEURL/WEUPD` outline for "whirlwind" as a mis-stroke due to missing a `B` stroke in its "n" sound, and prefer `WHEURL/WEUPBD` in the Gutenberg dictionary.