### PR TITLE
Prefer long "o" vowel in outline for "Hanover" in Gutenberg dictionary.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9949,7 +9949,7 @@
 "UPB/TRAOU": "untrue",
 "RE/SKWREBGS": "rejection",
 "TKPWRAEUGT": "grating",
-"HAPB/OFR": "Hanover",
+"HAPB/O*EFR": "Hanover",
 "EUPB/SPAOERPBS/-D": "inexperienced",
 "PHOPB": "mon",
 "WEUPBT/REU": "wintry",


### PR DESCRIPTION
This PR proposes to prefer a long "ō" vowel in the outline for "Hanover" in the Gutenberg dictionary.