### PR TITLE
Add Plover `SHOEUD` outline for "shadow"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -88101,6 +88101,7 @@
 "SHOES": "shows",
 "SHOEU": "he should",
 "SHOEU/SAEU": "I should say",
+"SHOEUD": "shadow",
 "SHOEUL": "shallow",
 "SHOEUPB": "shiny",
 "SHOEZ": "chose",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1344,7 +1344,7 @@
 "TAOEURD": "tired",
 "HRAEGD": "leading",
 "KEUL": "kill",
-"SHO*EUD": "shadow",
+"SHOEUD": "shadow",
 "KPAPB/KWROPB": "companion",
 "WAET": "weight",
 "PHAS": "mass",


### PR DESCRIPTION
This PR proposes to add Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s `SHOEUD` outline for "shadow", and use it in the Gutenberg dictionary.