### PR TITLE
Change outline for "material" to `TAOERL`

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -737,6 +737,7 @@
 "TEL/KPHAOUPB/KAEUGS/-S": "telecommunications",
 "TEL/KPHRAOUPB/KAEUGS/-S": "telecommunications",
 "TEPGS": "tension",
+"TERL": "material",
 "TERPL/TKOLG/EUFT": "dermatologist",
 "TEUBG/SEUPB/TPHR-RB": "Tikosyn",
 "TEUFT": "{^ticity}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -107700,7 +107700,7 @@
 "TERG/TEU": "integrity",
 "TERG/TOL": "Tegretol",
 "TERGT": "integrity",
-"TERL": "material",
+"TERL": "teller",
 "TERL/HRAOEUZ": "materialize",
 "TERL/TEU": "materiality",
 "TERP": "interpret",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1367,7 +1367,7 @@
 "TPHAT": "national",
 "WAEBG": "weak",
 "TKWAOEUPB": "divine",
-"TERL": "material",
+"TAOERL": "material",
 "PRAL": "principal",
 "TKPWAERD": "gathered",
 "SUGD": "suggested",


### PR DESCRIPTION
The `TERL` outline now outputs "teller", rather than "material" in Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33), so this PR proposes to:

- Change `TERL` entry in `dict.json` to reference "teller"
- Add `TERL` for "material" to `bad-habits.json`
- Use `TAOERL` outline in the Gutenberg dictionary for "material"