### PR TITLE
Prefer `SHRERPBLG` outline for "soldier"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -602,6 +602,7 @@
 "SHO/TKPWREP": "Sjogren",
 "SHRA*EUGS": "insulation",
 "SHREPD": "slept",
+"SHRERPBL": "soldier",
 "SKAOUS/EUF": "exclusive",
 "SKAOUS/EUFL": "exclusively",
 "SKAPL": "{!}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -88775,7 +88775,6 @@
 "SHRERGS": "acceleration",
 "SHRERPBD": "slender",
 "SHRERPBD/K-L": "cylindrical",
-"SHRERPBL": "soldier",
 "SHRERPBLG": "soldier",
 "SHRERPBLGS": "soldiers",
 "SHRERPL": "short-term",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1615,7 +1615,7 @@
 "SPHRAEUPB": "explain",
 "TAEUPB": "contain",
 "TKPWRAOEF": "grief",
-"SHRERPBL": "soldier",
+"SHRERPBLG": "soldier",
 "WAEPBT": "wasn't",
 "KOUPBT/TPHAPBS": "countenance",
 "PRAOEF": "previous",


### PR DESCRIPTION
This PR proposes to prefer `SHRERPBLG` outline for "soldier", and mark the `SHRERPBL` outline for "soldier" as a mis-stroke due to missing a `G` stroke in the `PBLG` "j" sound.