### PR TITLE
Prefer `TPHAOEDZ` outline for "needs" in Gutenberg dictionary, and ma…

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -747,6 +747,7 @@
 "TEUFT": "{^ticity}",
 "TEUPBG/WEURB": "distinguish",
 "TH-PL": "{.}",
+"THAOEDZ": "needs",
 "THAOEFRT/K-L": "theatrical",
 "THAOERT/K-L": "theoretical",
 "THAOUS/AFPL": "enthusiasm",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -108361,7 +108361,6 @@
 "THAOEBG/KWRA": "theca",
 "THAOEBS": "Thebes",
 "THAOEBS/KWRAPB": "Thebesian",
-"THAOEDZ": "needs",
 "THAOEF": "thief",
 "THAOEF/-G": "thieving",
 "THAOEF/-S": "thieves",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1730,7 +1730,7 @@
 "A/TKREFD": "addressed",
 "KHOEUS": "choice",
 "HAOUPBLG": "huge",
-"THAOEDZ": "needs",
+"TPHAOEDZ": "needs",
 "WAER": "wear",
 "PWHRAOEUPBD": "blind",
 "TPHA*EUBL": "unable",


### PR DESCRIPTION
This PR proposes to prefer the `TPHAOEDZ` outline for "needs" in Gutenberg dictionary, and mark `THAOEDZ` for "needs" as a mis-stroke due to missing `P` stroke in `TPH` "n" sound.