### PR TITLE
Add Plover `HR*ES` outline for "lest"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -259,6 +259,7 @@
 "HOPB/ORBL": "honorable",
 "HORS/PWABG": "horseback",
 "HOUD/*ER": "louder",
+"HR*ES": "LESS",
 "HRAEUD/EUS/AE": "lady's",
 "HRAO*EGT": "letting",
 "HRAO*EURB": "librarian",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -24717,7 +24717,7 @@
 "HR*ERPB/*ER": "Lerner",
 "HR*ERPBD": "lender",
 "HR*ERS": "lesser",
-"HR*ES": "LESS",
+"HR*ES": "lest",
 "HR*ES/-S": "LESs",
 "HR*ES/ER": "Lester",
 "HR*ES/THEUPB": "lecithin",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1882,7 +1882,7 @@
 "PHRAPBS": "plans",
 "REPBD/TKERD": "rendered",
 "P*EUFPS": "pictures",
-"HRES/*T": "lest",
+"HR*ES": "lest",
 "SROL/TAOERS": "volunteers",
 "SEUPBG/-G": "singing",
 "AOERG": "eager",


### PR DESCRIPTION
This PR proposes to add Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33)'s `HR*ES` outline for "lest", and have the Gutenberg dictionary prefer it over `HRES/*T`.