### PR TITLE
Have Gutenberg dictionary prefer `WRAOEUR` outline with long "ī" sound for "writer"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1915,7 +1915,7 @@
 "TKWOETD": "devoted",
 "PAEUG": "paying",
 "HREUT/REU": "literary",
-"WREUR": "writer",
+"WRAOEUR": "writer",
 "TP*/TPH*": "fn",
 "EUZ/RAEL": "Israel",
 "TKEUS/PAOERD": "disappeared",


### PR DESCRIPTION
This PR proposes to have the Gutenberg dictionary prefer `WRAOEUR` outline with long "ī" sound for "writer" to match word pronunciation (but not consider the orthographic entry a mis-stroke).