### PR TITLE
Have the Gutenberg dictionary prefer a long "ī" sound in outline for "violent" (`SRAOEUPBLT`)

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1985,7 +1985,7 @@
 "RORD": "record",
 "TPAT": "fat",
 "SAPBD": "sand",
-"SROEUPBLT": "violent",
+"SRAOEUPBLT": "violent",
 "PWRAFRPBS": "branches",
 "EUPB/KWAOEURD": "inquired",
 "4-R": "IV",


### PR DESCRIPTION
This PR proposes to have the Gutenberg dictionary prefer a long "ī" sound in outline for "violent" (`SRAOEUPBLT`) rather than what looks like an orthographic entry with inversion(?) (`SROEUPBLT`).