### PR TITLE
Fix Gutenberg outline for "frightened": add a missing `F` to make `TPRAOEUFPBD`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2072,7 +2072,7 @@
 "HRAOEUBG/WAOEUS": "likewise",
 "SAO*EUT": "site",
 "SAEUL": "sail",
-"TPRAOEUPBD": "frightened",
+"TPRAOEUFPBD": "frightened",
 "A/KWAEUPBTD": "acquainted",
 "UPB/HAEP": "unhappy",
 "TPAOERD": "feared",


### PR DESCRIPTION
This PR proposes to fix the Gutenberg outline for "frightened" by adding a missing `F` to make `TPRAOEUFPBD`. `TPRAOEUPBD` for "frightened" doesn't appear in any of the other dictionaries, and isn't in Plover, so perhaps this was a typo?