### PR TITLE
Mark `KAEULT` outline for "indicate" as a mis-stroke, prefer `KA*EUT`

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -285,6 +285,7 @@
 "HUPBD/SKWRU": "Hindu",
 "K-FRPL/TEU": "conformity",
 "KA/TAOED/RAL": "cathedral",
+"KAEULT": "indicate",
 "KAFT/AOEURP": "cast-iron",
 "KALS/TOEPB/*EUP": "calcitonin",
 "KAO*ERP": "{^keeper}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -30334,7 +30334,6 @@
 "KAEUL/KWRA": "Kayla",
 "KAEUL/SAOEZ": "calices",
 "KAEULGS": "calyx",
-"KAEULT": "indicate",
 "KAEUP": "cape",
 "KAEUP/-BL": "capable",
 "KAEUP/-BLT": "capability",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2224,7 +2224,7 @@
 "TPHOD/-D": "nodded",
 "ST*TS": "status",
 "P-PBS": "opinions",
-"KAEULT": "indicate",
+"KA*EUT": "indicate",
 "POEPL": "poem",
 "SA*FPBLG": "savage",
 "A/RAOEUS": "arise",


### PR DESCRIPTION
This PR proposes a change that goes a bit against the general rules of these dictionaries:

Mark `KAEULT` outline for "indicate" as a mis-stroke due to potentially confusing use of `L` stroke (it confused me, anyway: "indicalte"?), and prefer `KA*EUT` instead. Even though `KA*EUT` uses an asterisk, I think it more accurately represents the pronunciation of "indicate" and is easier to remember.