### PR TITLE
Fix casing for outlines for "western" and "eastern" used in Gutenberg dictionary.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2598,7 +2598,7 @@
 "KOFTS": "costs",
 "THREFPBD": "threatened",
 "ARPBG/*PLT": "arrangement",
-"WERPB": "western",
+"WES/TERPB": "western",
 "SAPBG": "sang",
 "-BGZ": "beings",
 "SAPL": "Sam",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3421,7 +3421,7 @@
 "PEU/*ER": "Pierre",
 "S*UPBG": "sunk",
 "RAOUPBS": "ruins",
-"AOERPB": "eastern",
+"AOEFT/ERPB": "eastern",
 "ROES/-S": "roses",
 "SEUT/*EPB": "citizen",
 "RE/PHAOEUPBD/T-D": "reminded",


### PR DESCRIPTION
The current outline for "western" in the Gutenberg dictionary outputs to "Western" with a capital "W", so this PR proposes to change this to the outline for lowercase "western".

Same for the outline for "eastern".