### PR TITLE
Fix outline for "Saturday": `SAET` outputs "seat", change to `SATD`

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -583,6 +583,7 @@
 "S*EURT/PHAO*EUPB": "erythromycin",
 "S*EURT/PHAOEUS/*EUB": "erythromycin",
 "SA/RA": "Sarah",
+"SAET": "Saturday",
 "SAL/SRAUGS": "salvation",
 "SAO*EUD/A*L": "{^cidal}",
 "SAOER/KWRUS": "serious",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -82084,7 +82084,7 @@
 "SAERS": "Sears",
 "SAERZ": "Sears",
 "SAES": "seas",
-"SAET": "Saturday",
+"SAET": "seat",
 "SAET/AOEPBG/POEFT": "Saturday Evening Post",
 "SAET/REU": "satisfactory",
 "SAET/TPHAOEUT/HREUF": "Saturday Night Live",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2685,7 +2685,7 @@
 "SEPBS/-BL": "sensible",
 "OE/-G": "owing",
 "PHART/EUPB": "Martin",
-"SAET": "Saturday",
+"SATD": "Saturday",
 "KOT/APBLG": "cottage",
 "SKWRAOUZ": "Jews",
 "HRAOEPBG": "leaning",


### PR DESCRIPTION
This PR proposes to fix the "Saturday" outline: the current one, `SAET`, outputs "seat". So, fix that outline and prefer the `SATD` outline for "Saturday" in the Gutenberg dictionary (chosen over `SARD` since I personally found it more intuitive to stroke: you have to make the reach for `D` regardless of which of the two outlines you use).