### PR TITLE
Change entry for `PORPLS` outline to "performs" rather than "performance"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -490,6 +490,7 @@
 "PHURD/RUS": "murderous",
 "POEP/-LS": "hopeless",
 "POEUPBT/PWHRAPBG": "pointblank",
+"PORPLS": "performance",
 "PORS/PWA*BG": "horseback",
 "PORT/KPWAL": "Portugal",
 "PORT/TKWAOES": "Portuguese",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -62815,7 +62815,7 @@
 "PORPL/TEUF": "performative",
 "PORPLD": "performed",
 "PORPLG": "performing",
-"PORPLS": "performance",
+"PORPLS": "performs",
 "PORS/AOEUPB": "porcine",
 "PORS/HRAEUPB": "porcelain",
 "PORS/HRAPB": "porcelain",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2962,7 +2962,7 @@
 "TKPWAER": "gather",
 "TK*EPT": "depth",
 "EUPB/TKEUG/TPHAEUGS": "indignation",
-"PORPLS": "performance",
+"P-FRPBS": "performance",
 "HREBGS": "election",
 "PROFP/ERT": "prosperity",
 "TKPWHRAOPL/KWREU": "gloomy",


### PR DESCRIPTION
This PR proposes to change the entry for the `PORPLS` outline to specify an output of "performs", rather than "performance" as per behaviour in  Plover release [weekly-v4.0.0.dev8+66.g685bd33](https://github.com/openstenoproject/plover/releases/tag/weekly-v4.0.0.dev8%2B66.g685bd33).

As a result of this, also change the Gutenberg dictionary entry for "performance" to use the `P-FRPBS` outline, which is my favoured option.