### PR TITLE
Give Gutenberg outline for "newspaper" a long "ū" vowel sound

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1478,6 +1478,7 @@
 "TPHAOER/-PBS": "nearness",
 "TPHAOET/-PBS": "neatness",
 "TPHAOET/EFT": "neatest",
+"TPHAOUPS": "newspapers",
 "TPHARL/EUFT": "naturalist",
 "TPHEFRB/-D": "nerved",
 "TPHEFRB/G": "nerving",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3643,7 +3643,7 @@
 "KULT/SRAEUT/-D": "cultivated",
 "TPHRURBD": "flushed",
 "SHAEUBG/SPAOER": "Shakespeare",
-"TPHUPS": "newspapers",
+"TPHAOUPS": "newspapers",
 "ROBG/KEU": "rocky",
 "PAOEU/OUS": "pious",
 "WO*PBT": "wont",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3047,7 +3047,7 @@
 "TREUP": "trip",
 "SHAOT": "shoot",
 "TP-RPBT": "fortunate",
-"TPHUP": "newspaper",
+"TPHAOUP": "newspaper",
 "PHROEUPLT": "employment",
 "TPEUTD": "fitted",
 "REF/AOUPBLG": "refuge",


### PR DESCRIPTION
This PR proposes to give the Gutenberg dictionary outline for "newspaper" a long "ū" vowel sound to more accurately reflect the vowel in "news". I keep on pronouncing "nup" (as in "yep"/"nup") in my head 😆 