### PR TITLE
Change outline for "wearing" to `WAERG`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3246,7 +3246,7 @@
 "SPAPB/KWRARDZ": "Spaniards",
 "TKPWRAEUPB": "grain",
 "SKWROEUPLT": "enjoyment",
-"WAURG": "wearing",
+"WAERG": "wearing",
 "EUPB/TKEUFRPBS": "indifference",
 "KAUPB/SAOEL": "conceal",
 "HORZ/O*PB": "horizon",


### PR DESCRIPTION
 This PR proposes to change the outline for "wearing" used in the Gutenberg dictionary to match with the `WAER` outline for "wear". `WAURG` ("wawring"?) looks a bit to me like a mis-stroke, but I'm guessing there is an accent that pronounces it that way, so I'm happy to leave it be.