### PR TITLE
Outline preference proposals

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -34976,6 +34976,7 @@
 "KHOUD/*ER": "chowder",
 "KHOUD/ER": "chowder",
 "KHOUD/ERS": "chowders",
+"KHOURS": "chorus",
 "KHR*BG": "{#Control_L(k)}",
 "KHR*EBGS": "collection",
 "KHR*EF/ER": "clever",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -80522,6 +80522,8 @@
 "ROEZ/SEU": "rosy",
 "ROEZ/SEU/*PBS": "rosiness",
 "ROEZ/SRELT": "Roosevelt",
+"RO*F": "resolve",
+"ROF": "resolve",
 "ROF/KWREU": "recovery",
 "ROFG": "roving",
 "ROFL": "Rolf",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -50431,6 +50431,7 @@
 "PARB/PHAOEPB/TPHA": "pashmina",
 "PARB/TPHAT": "passionate",
 "PARBG": "park",
+"PARBG/*ER": "Parker",
 "PARBG/*EUPB/SO*EPB": "Parkinson",
 "PARBG/*EUPB/SO*PB": "Parkinson",
 "PARBG/-D": "parked",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5981,7 +5981,7 @@
 "TAOUB": "tube",
 "OERB": "observer",
 "SPHOET": "smote",
-"AFP": "avenue",
+"AEF": "avenue",
 "EL/TPAPBT": "elephant",
 "PWURBG": "Burke",
 "TPAOGT": "footing",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6234,7 +6234,7 @@
 "TKEBG/RAEUT/-D": "decorated",
 "SEPBT/PHEPBL": "sentimental",
 "KWRO*EBG": "yoke",
-"PROTS": "properties",
+"PROPTS": "properties",
 "WAR/SKWRAOEUBG": "warlike",
 "PERL/OUS": "perilous",
 "THRETS": "threats",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5953,7 +5953,7 @@
 "PWAB/HROPB": "Babylon",
 "TKUS/TEU": "dusty",
 "PWEURB/OPS": "bishops",
-"KHRAOEUPBS": "complaints",
+"KPHRAEUPBTS": "complaints",
 "STREUPD": "stripped",
 "PHRAOED": "plead",
 "HEUPBD/ER": "hinder",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5067,7 +5067,7 @@
 "STEUBGS": "sticks",
 "TKRAG": "drag",
 "HAUPBT/-D": "haunted",
-"KHOERS": "chorus",
+"KHOURS": "chorus",
 "RALG": "rational",
 "KROP": "crop",
 "PROEUFG": "processing",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5038,7 +5038,7 @@
 "PAERPB": "pattern",
 "RE/SRAOEL": "reveal",
 "EPB/TKAOURD": "endured",
-"RE/SOL/*F": "resolve",
+"ROF": "resolve",
 "KHRUPL/KWRA": "Columbia",
 "PRAOEFP": "preach",
 "EBGS/SAOED/-G": "exceeding",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6612,7 +6612,7 @@
 "RAP/KHUR": "rapture",
 "TOPBT": "tonight",
 "TRUPLT": "trumpet",
-"PA*RBG/ER": "Parker",
+"PARBG/*ER": "Parker",
 "EPB/TRUFT/-D": "entrusted",
 "TPEURPL/-PBS": "firmness",
 "KO*BG": "comic",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4388,7 +4388,7 @@
 "KOUFP": "couch",
 "PWEULS": "bills",
 "WARPBT": "warrant",
-"KPAEUPBT": "complaint",
+"KPHRAEUPBT": "complaint",
 "EPB/TKEUFR/A*U": "endeavour",
 "SAEULS": "sails",
 "TKAOEUPBD": "dined",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6018,7 +6018,7 @@
 "PWEG/-G": "begging",
 "EUPL/POES/-G": "imposing",
 "TPHOET/-BL": "notable",
-"SEFD": "invested",
+"SREFD": "invested",
 "EUPL/PREUS/OPBD": "imprisoned",
 "PHAOUT": "mute",
 "AEUPL/KWREU": "Amy",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5797,7 +5797,7 @@
 "RE/PAOET/TKHREU": "repeatedly",
 "KOPB/SPEUR/SEU": "conspiracy",
 "RE/STRAEUPB": "restrain",
-"SHREPBD/O*R": "splendor",
+"SPHREPBD/O*R": "splendor",
 "PREFRGS": "preservation",
 "PUB": "pub",
 "PAOERP": "pepper",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6487,7 +6487,7 @@
 "SPAERBS": "spacious",
 "TAEURG": "tearing",
 "A/TPHREUBGS": "affliction",
-"TPOEF": "photograph",
+"TPRAF": "photograph",
 "AL/HREU": "ally",
 "HA*PL/SHEUR": "Hampshire",
 "A/SKREPBT": "ascent",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4330,7 +4330,7 @@
 "SRAOUD": "viewed",
 "STKAOEUPBS": "designs",
 "TKPWHRAOEPL": "gleam",
-"THEFPBG": "threatening",
+"THREFPBG": "threatening",
 "PAPL": "palm",
 "PHO*": "Missouri",
 "TPEULG": "filling",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4077,7 +4077,7 @@
 "SKRETS": "secrets",
 "TPH*/A*": "na",
 "HAULT/-D": "halted",
-"TKPWOFPB": "govern",
+"TKPWOFRPB": "govern",
 "TPAEUFRBL/A*U": "favourable",
 "KHRORS": "colors",
 "THRAEUTD": "translated",


### PR DESCRIPTION
This PR proposes to make some changes, mostly to the Gutenberg dictionary, to outlines where there is no issue with the current outline, but I subjectively think another outline is better, some of which are new outlines added to `dict.json`. Details are in each commit.