### PR TITLE
Mark `STOERPL` outline for "storm" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -694,6 +694,7 @@
 "STEUPGS": "estimation",
 "STH/PHOEUFP/TPHR-RB": "{?}",
 "STKPH": "{?}",
+"STOERPL": "storm",
 "STP": "{?}",
 "STPH": "{?}",
 "STPH*": "{?}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -101658,7 +101658,7 @@
 "STOER/THAS": "stories that",
 "STOERPB": "state's attorney",
 "STOERPBLG": "storage",
-"STOERPL": "storm",
+"STOERPL": "stormy",
 "STOERS": "stories",
 "STOES": "stows",
 "STOET": "stoat",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5994,7 +5994,7 @@
 "*ES/THER": "Esther",
 "*EUPBD": "Indiana",
 "A/TPEBGT/-G": "affecting",
-"STOR/PH*EU": "stormy",
+"STOERPL": "stormy",
 "PWAOE": "bee",
 "PWUR/REU": "bury",
 "TP-RBT": "efficient",


### PR DESCRIPTION
This PR proposes to mark the `STOERPL` outline for "storm" as a mis-stroke as it now outputs "stormy". As a result of this, prefer usage of single-stroke `STOERPL` over `STOR/PH*EU` in
the Gutenberg dictionary.