### PR TITLE
Add Plover `TP*ERT` outline for "feather"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -121711,6 +121711,7 @@
 "TP*EPB/TPHEUG": "pfennig",
 "TP*EPL/TAOUR": "temperature",
 "TP*ER/PHOEPB": "pheromone",
+"TP*ERT": "feather",
 "TP*ES": "fest",
 "TP*ES/*EUF": "festive",
 "TP*ES/*EUF/TEU": "festivity",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6172,7 +6172,7 @@
 "TRUPB/-BGS": "trunks",
 "SRER/HREU": "verily",
 "HURPBTS": "hunters",
-"TP*ET": "feather",
+"TP*ERT": "feather",
 "TKES/PRAT/HREU": "desperately",
 "TKPWAOD/HREU": "goodly",
 "HABT/WAL": "habitual",


### PR DESCRIPTION
This PR proposes to add the Plover single-stroke outline `TP*ERT` for "feather" to `dict.json`, and have the Gutenberg dictionary prefer it.