### PR TITLE
Change outline for "casual" used in Gutenberg dictionary to `KARBL`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6638,7 +6638,7 @@
 "PRABGS/A*U": "practise",
 "SAPBGT/WAER": "sanctuary",
 "SAOUP/STEURBS": "superstitious",
-"KAEFL": "casual",
+"KARBL": "casual",
 "WO*EU": "Iowa",
 "AEPBLD": "analyzed",
 "HEUFT/R-G": "historic",


### PR DESCRIPTION
This PR proposes to change the outline for "casual" used in Gutenberg dictionary to `KARBL` to better match the word pronunciation ("cashl" vs "keasl").