### PR TITLE
Mark `TKRAFL` for "gravel" as a mis-stroke due to missing the `PW` in "g" sound.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -859,6 +859,7 @@
 "TKR-RBTD": "distributed",
 "TKR-RGS": "distribution",
 "TKR-RPBT/-D": "distributed",
+"TKRAFL": "gravel",
 "TKRAO/PEU": "droopy",
 "TKRAOFG": "driving",
 "TKRAOP/*GD": "drooping",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -119871,7 +119871,6 @@
 "TKRAF/TEU/*PBS": "draftiness",
 "TKRAFBG": "drastic",
 "TKRAFGT": "drafting",
-"TKRAFL": "gravel",
 "TKRAFT": "draft",
 "TKRAFT/-D": "drafted",
 "TKRAFT/-G": "drafting",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6717,7 +6717,7 @@
 "PWHRAEUPLD": "blamed",
 "TPHAOED/-FL": "needful",
 "TPAOEUR/PHRAEUS": "fireplace",
-"TKRAFL": "gravel",
+"TKPWRAFL": "gravel",
 "AFRDZ": "affords",
 "SKOFRG": "discovering",
 "SKWRAR": "jar",


### PR DESCRIPTION
This PR proposes to mark `TKRAFL` for "gravel" as a mis-stroke (even though it's a Plover dictionary outline) due to missing the `PW` strokes in the `TKPW` "g" sound. As a result of this, it also proposes to have the Gutenberg dictionary prefer the `TKPWRAFL` outline.