### PR TITLE
Change Gutenberg outline for "retirement" to `RAO*EURPLT`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6804,7 +6804,7 @@
 "PER/PET/WAEL": "perpetually",
 "ARB/TRAER": "arbitrary",
 "EBG/STEU": "ecstasy",
-"RAO*EUPLT": "retirement",
+"RAO*EURPLT": "retirement",
 "PROUPBS": "pronounce",
 "THORD": "authorized",
 "TPAPLT": "familiarity",


### PR DESCRIPTION
This PR proposes to change the Gutenberg outline for "retirement" to `RAO*EURPLT` to more accurately reflect word pronunciation (and for whatever reason, I found this outline more natural to stroke than the current `RAO*EUPLT`).