### PR TITLE
Add Plover outline for "cum"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -40958,6 +40958,7 @@
 "KR*T/KR*T": "Connecticut",
 "KR*UBGS": "crux",
 "KR*UF": "constructive",
+"KR*UPL": "cum",
 "KR*UPL/*L": "crumple",
 "KR*UPL/-BL": "crumple",
 "KR*UPL/HREUPBG": "crumpling",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6880,7 +6880,7 @@
 "TKPWOT/EUBG": "Gothic",
 "KAOL/-PBS": "coolness",
 "EUPB/SREBGS": "insurrection",
-"KR*/*U/PH*": "cum",
+"KR*UPL": "cum",
 "PH*ED": "med",
 "KOEFP/PHAPB": "coachman",
 "KPEPBD": "expend",


### PR DESCRIPTION
There is a Plover outline for "cum" (`KR*UPL`), so this PR proposes to add it to `dict.json` and have the Gutenberg dictionary use it.