### PR TITLE
Change Gutenberg outline for "employer" to `PHROEUR`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6915,7 +6915,7 @@
 "PWUR/KWRAL": "burial",
 "PHA*T/-T": "Matt",
 "PHROE": "employee",
-"PHROER": "employer",
+"PHROEUR": "employer",
 "HA*ES": "hypothesis",
 "STAOED": "steed",
 "WEUTD": "width",


### PR DESCRIPTION
Outline `PHROER` for "employer" comes from a personal Di brief that is not in Plover (it outputs "PHROER" as-is):

https://github.com/didoesdigital/steno-dictionaries/blob/47fabaf8affaa8fdb472c02d5b97232396d2afb7/dictionaries/di-briefs.json#L10

Therefore, this PR proposes to change the Gutenberg dictionary to use Plover outline `PHROEUR` instead.