### PR TITLE
Use `PEUGZ` for "pigs" in Gutenberg dictionary

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -52423,7 +52423,7 @@
 "PEUG/TAEUL": "pigtail",
 "PEUGS": "pigeon",
 "PEUGS/HOEL": "pigeonhole",
-"PEUGZ": " pigs",
+"PEUGZ": "pigs",
 "PEUL": "pill",
 "PEUL/-S": "pills",
 "PEUL/A*R": "pillar",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6973,7 +6973,7 @@
 "RAOE/TPHREBGT/-G": "reflecting",
 "PEPBGS": "pension",
 "HRUBGS/WUS": "luxurious",
-"PAO*EGS": "pigs",
+"PEUGZ": "pigs",
 "KHOEUR": "choir",
 "TUPL/-BLD": "tumbled",
 "KO*PBG/RER": "conqueror",


### PR DESCRIPTION
This PR proposes to fix the `dict.json` outline for "pigs" that has an unneeded extra space (I'm assuming this was a typo...?), and have `PEUGZ` be the preferred outline for "pigs" in the Gutenberg dictionary as I think it's a better match pronunciation-wise ("pigz" vs "pēgs").