### PR TITLE
Mark `KHAOER/*ER` for "clearer" as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -319,6 +319,7 @@
 "KEFPBS": "convention",
 "KHAEUPGS": "changes",
 "KHAOEPB": "clean",
+"KHAOER/*ER": "clearer",
 "KHAOEUPLT": "climate",
 "KHAR/HREU": "Charlie",
 "KHARPBLD": "charged",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -34172,7 +34172,6 @@
 "KHAOEPL/TABGS/EUS": "chemotaxis",
 "KHAOEPL/THER/PEU": "chemotherapy",
 "KHAOER": "cheer",
-"KHAOER/*ER": "clearer",
 "KHAOER/-FL": "cheerful",
 "KHAOER/-LS": "cheerless",
 "KHAOER/-LS/HREU": "cheerlessly",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7046,7 +7046,7 @@
 "SA/TEUPB": "satin",
 "TKEUS/PHRAOES/-D": "displeased",
 "O*ERD": "odor",
-"KHAOER/*ER": "clearer",
+"KHRAOER/*ER": "clearer",
 "PRAR/AO*E": "prairie",
 "HUD/SOPB": "Hudson",
 "TPAOU/TKAL": "feudal",


### PR DESCRIPTION
The outline `KHAOER/*ER` for "clearer" is missing a `R` stroke in the `HR` "l" sound, so this PR proposes to mark it as a mis-stroke. As a result of this, also have the Gutenberg dictionary prefer `KHRAOER/*ER` for "clearer".