### PR TITLE
Mark `TOFRB` for "torch" as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -886,6 +886,7 @@
 "TKWHREUFR": "deliver",
 "TKWR-BGS": "distribution",
 "TO/REU/TKR-RBT": "to redistribute",
+"TOFRB": "torch",
 "TP-BG": "{,}",
 "TP-F": "{.}",
 "TP-FPL": "{.}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -121270,7 +121270,6 @@
 "TOFL": "to feel",
 "TOFL/PHAOEUR": "Tofflemire",
 "TOFPBD": "to find",
-"TOFRB": "torch",
 "TOFRP/SOPB": "Thompson",
 "TOFRPB": "torch",
 "TOG": "{^ing to}",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7079,7 +7079,7 @@
 "PEUL/AR": "pillar",
 "EUPL/PORT": "import",
 "TPOURPBD": "founder",
-"TOFRB": "torch",
+"TOFRPB": "torch",
 "SRAULT": "vault",
 "WORPL": "worm",
 "A/KWR*": "ay",


### PR DESCRIPTION
Outline `TOFRB` for "torch" is missing a `P` stroke for the `FRPB` "rch" sound, so this PR proposes to mark it as a mis-stroke. As a result of this, have the Gutenberg dictionary prefer `TOFRPB` for "torch".