### PR TITLE
Have Gutenberg dictionary prefer `SAOERPB` outline for "senior"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7114,7 +7114,7 @@
 "PHUD/KWREU": "muddy",
 "AFRPBS": "arches",
 "SPAEBGS": "aspects",
-"SOEURPB": "senior",
+"SAOERPB": "senior",
 "TPRAEUG/RAPBS": "fragrance",
 "KHROEPBL": "colonial",
 "PEPB/TRAEUGT": "penetrating",


### PR DESCRIPTION
This PR proposes to have the Gutenberg dictionary prefer the `SAOERPB` outline for "senior" to place more emphasis on the long "ē" sound of the word pronunciation. Personally, I think it's a better match ("sēnr" vs "soinr").