### PR TITLE
Have the Gutenberg dictionary prefer the `TPWARDZ` outline for "forwards"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7282,7 +7282,7 @@
 "PAT": "pat",
 "A/RAEUB/KWRAPB": "Arabian",
 "TKHR*OG": "dialogue",
-"TPAORDZ": "forwards",
+"TPWARDZ": "forwards",
 "SPWRAOET": "entreat",
 "TPAS/TPHAEUGS": "fascination",
 "PWEL/HREU": "belly",


### PR DESCRIPTION
This PR proposes to have the Gutenberg dictionary prefer the `TPWARDZ` outline for "forwards" to more accurately match word pronunciation ("fwardz" vs "fōrdz").