### PR TITLE
Have Gutenberg dictionary prefer the "ta" outline from `dict-en-AU-with-extra-stroke.json`

### DIFF
--- a/dictionaries/dict-en-AU-with-extra-stroke.json
+++ b/dictionaries/dict-en-AU-with-extra-stroke.json
@@ -1998,6 +1998,7 @@
 "SWEUFL/*LG/A*U": "swivelling",
 "T*EPL/O*R/AOEUZ/-G/A*U": "temporising",
 "T*EPL/RAO*EUZ/A*U": "temporise",
+"TA/A*U": "ta",
 "TAEU/A*U": "ta",
 "TAOEL/AOEUZ/-Z/A*U": "materialises",
 "TAOER/TPHAOEUZ/A*U": "tyrannise",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7329,7 +7329,7 @@
 "PERPBT": "persistent",
 "W*EU": "Wisconsin",
 "HO*E": "ho",
-"TAEU": "ta",
+"TA/A*U": "ta",
 "TPRAOUT/-FL": "fruitful",
 "SKOUPBD/REL": "scoundrel",
 "KOEFTS": "coasts",


### PR DESCRIPTION
This PR proposes to have Gutenberg dictionary prefer the "ta" outline from `dict-en-AU-with-extra-stroke.json` over `dict-en-AU-vocab.json`.

I'm a bit conflicted over this, because it's not possible to know in advance which of the AU dictionaries a student is going to use while doing Typey Type exercises. Personally, I use the `dict-en-AU-with-extra-stroke.json` dictionary, and many of the other AU-based strokes that show up in Typey Type lean more into that dictionary than `dict-en-AU-vocab.json`, which I think by itself justifies this change.

The way to make it all neutral, of course, is to simply change this entry to be fingerspelling, which I'd be okay with as well.