### PR TITLE
Mark `AL` for "Al" as a mis-stroke since it outputs "al".

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -69,6 +69,7 @@
 "AEUR/TEU": "{^arity}",
 "AFG": "average",
 "AG/ROUPBD": "{^ing}{^a}",
+"AL": "Al",
 "AL/PHAOEU/TEU": "almighty",
 "AL/PHAOEUG/TEU": "almighty",
 "AL/PHAOEUG/TEU/HREU": "almightily",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -6076,7 +6076,7 @@
 "AGT/ORPB/-PBLG": "Agent Orange",
 "AGT/ORPBG": "Agent Orange",
 "AGT/SEU": "agency",
-"AL": "Al",
+"AL": "al",
 "AL/*EPB": "Allen",
 "AL/*EPB/TKUBG/AS": "Alain Ducasse",
 "AL/*ER/SKWREPB": "allergen",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7410,7 +7410,7 @@
 "TPORPB/ER": "foreigner",
 "EPB/TKEUFRG/A*U": "endeavouring",
 "SA/TAOEUR": "satire",
-"AL": "Al",
+"AL/AL": "Al",
 "TKHRAOET": "delete",
 "PHAS/KHREUPB": "masculine",
 "SPAOEU/-S": "spies",


### PR DESCRIPTION
This PR proposes to mark `AL` for "Al" as a mis-stroke since `AL` is used for lowercase "al".
Therefore, it also proposes to change the `dict.json` entry for outline `AL` to be "al", and change the outline used for "Al" in the Gutenberg dictionary to be `AL/AL`.