### PR TITLE
Change Gutenberg outline used for "Wright" to `WRAOEUGT`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7477,7 +7477,7 @@
 "THREFPB": "threaten",
 "TPHUTS": "nuts",
 "UPB/TKOPB": "undone",
-"WRA*ET": "Wright",
+"WRAOEUGT": "Wright",
 "TPRAPBG/-PBS": "frankness",
 "HAOEUDZ": "hides",
 "PROG/EUF": "progressive",


### PR DESCRIPTION
This PR proposes to change the Gutenberg outline used for "Wright" to `WRAOEUGT` to more accurately match word pronunciation (with the bonus of it still being single-stroked and it doesn't have to use an asterisk).