### PR TITLE
Add Plover `EURS` outline for "IRS"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -20035,6 +20035,7 @@
 "EURPL": "I remember",
 "EURPL/KWRA": "Irma",
 "EURPLD": "I remembered",
+"EURS": "IRS",
 "EURT": "irrelevant",
 "EURT/-BL": "irritable",
 "EURT/-BLT": "irritability",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7485,7 +7485,7 @@
 "SREUL/A": "villa",
 "ARS/TOT/-L": "Aristotle",
 "SRORS": "resource",
-"EURBGS/R*S": "IRS",
+"EURS": "IRS",
 "KAUPB/TPAOEUPB": "confine",
 "SWEG": "sewing",
 "KR*/O*": "co",


### PR DESCRIPTION
This PR proposes to add the Plover `EURS` outline for "IRS" to `dict.json`, and have the Gutenberg prefer it since it's single-stroke and easier to remember.