### PR TITLE
Change Gutenberg outline for "restaurant" to `STRAUPBT`.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7550,7 +7550,7 @@
 "EUPB/SEBGT": "insect",
 "SRAOULS": "values",
 "PWRAOD/-G": "brooding",
-"TRAUPBT": "restaurant",
+"STRAUPBT": "restaurant",
 "PWAPT/EUFPL": "baptism",
 "PHAPBLG/TEUF": "imaginative",
 "RAOEUPL": "rhyme",


### PR DESCRIPTION
This PR proposes to change the Gutenberg outline for "restaurant" to `STRAUPBT` to better match its word pronunciation.