### PR TITLE
Add condensed stroke for "perils" `PER/EUL/-S` and have the Gutenberg

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -708,6 +708,7 @@
 "PB*P/R*/*U/*EU/TPH*": "Bruin",
 "PEPB/-D": "penned",
 "PEPB/TPHE/-D": "penned",
+"PER/EUL/-S": "perils",
 "PER/SRAEUD/-D": "pervaded",
 "PER/SRERS/-PBS": "perverseness",
 "PERPB/KWRA/-S": "personas",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7745,7 +7745,7 @@
 "PHAOEUPB/ORT": "minority",
 "SPAPB/KWRARD": "Spaniard",
 "REUPBLGS": "ridges",
-"P*ERL/-S": "perils",
+"PER/EUL/-S": "perils",
 "HRAR/REU": "Larry",
 "PH-DZ": "merchandise",
 "A/HRAOF": "aloof",


### PR DESCRIPTION
This PR proposes to add a condensed stroke for "perils" `PER/EUL/-S` and have the Gutenberg dictionary use it. The original outline used for "perils", `P*ERL/-S`, outputs "Perls".