### PR TITLE
Change "municipal" outline to `PHAOUPBS/PAL`

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -449,6 +449,7 @@
 "PHAOEUGT/TEU/*PBS": "mightiness",
 "PHAOEURBG/SOEFT": "Microsoft",
 "PHAOEUT/TEU": "mighty",
+"PHAOUPBS": "municipal",
 "PHAPB/STREUPT": "manuscript",
 "PHAPBL/TPHAEUGS": "imagination",
 "PHAR/ABG/HROUS": "miraculous",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -55528,7 +55528,7 @@
 "PHAOUPB/TKPWHROB": "immunoglobulin",
 "PHAOUPB/TPHEUS/PAL": "municipal",
 "PHAOUPBLG/HEU/TKAOEPB": "mujahideen",
-"PHAOUPBS": "municipal",
+"PHAOUPBS": "menus",
 "PHAOUPBS/PAL": "municipal",
 "PHAOUPBS/PALT": "municipality",
 "PHAOUPBS/PALT/-S": "municipalities",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7771,7 +7771,7 @@
 "PHEPBD": "mend",
 "K-RS": "considers",
 "TWEPBT/WUPB": "twenty-one",
-"PHAOUPBS": "municipal",
+"PHAOUPBS/PAL": "municipal",
 "A/KHAOEFPLTS": "achievements",
 "KHER/EURB": "cherish",
 "TKAOE/SER/-FG": "deserving",


### PR DESCRIPTION
The outline `PHAOUPBS` outputs "menus" rather than "municipal", so this PR proposes to:

- change the `dict.json` entry to reflect that
- mark `PHAOUPBS` for "municipal" as a mis-stroke
- have the Gutenberg dictionary prefer `PHAOUPBS/PAL` for "municipal".