### PR TITLE
Change Gutenberg outline for "dreamy" to `TKRAOEPL/KWREU`

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8002,7 +8002,7 @@
 "TAEPBT": "tenant",
 "PWURPBS": "burns",
 "HAR/PHOEPB/KWROUS": "harmonious",
-"TKRAOE/PH*EU": "dreamy",
+"TKRAOEPL/KWREU": "dreamy",
 "PWURG/TKEU": "burgundy",
 "KHREBGS/-S": "collections",
 "UPB/KAOEUPBD": "unkind",


### PR DESCRIPTION
This PR proposes to change the Gutenberg outline for "dreamy" to remove the asterisk, and leverage the `TKRAOEPL` outline for "dream". Personally, I also think it's a better division of the word ("dream-y" vs "drea-my").