### PR TITLE
Change "lone" outline to `HROEPB` with long "ō"

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8420,7 +8420,7 @@
 "A/TKAOU": "adieu",
 "SKHRAOUD": "exclude",
 "KARTS": "carts",
-"HROPB": "lone",
+"HROEPB": "lone",
 "WH*EUFBG/KWREU": "whisky",
 "PWAOUS/-S": "abuses",
 "EUPB/TPHREUBGT": "inflict",


### PR DESCRIPTION
This PR proposes to have the Gutenberg dictionary prefer a long "ō" vowel in outline for "lone".