### PR TITLE
Add `HRAEU/PWOUR/-D` condensed stroke for "laboured"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -394,6 +394,7 @@
 "HRA*ED/SH-P": "ladyship",
 "HRA*ED/SH-P/KW-BG": "ladyship,",
 "HRAD/SKWR*E": "lade",
+"HRAEU/PWOUR/-D": "laboured",
 "HRAEU/SKWROUPB": "laydown",
 "HRAOBG/TK-LS/SPHART": "looksmart",
 "HRAOD/*ER": "loader",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8450,7 +8450,7 @@
 "RAOE/KPEPBS": "recompense",
 "PHRA*PBG": "plank",
 "STPHUR": "insure",
-"HRAEU/PWOUR/-D/A*U": "laboured",
+"HRAEU/PWOUR/-D": "laboured",
 "KPAPBLG/RAEUGS": "exaggeration",
 "PH*/*EU": "mi",
 "SHEP/ERDZ": "shepherds",


### PR DESCRIPTION
This PR proposes to add a `HRAEU/PWOUR/-D` condensed stroke for "laboured", and have the Gutenberg dictionary prefer it.

It would seem that this entry does not need to be dependent on the AU dictionaries. Also, even if it is, when stroking this in Typey Type, the outline ends up finishing before you can stroke the final `A*U` suffix.