### PR TITLE
Add `TPHO*TS` condensed stroke for "knots".

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1524,6 +1524,7 @@
 "TPHEUG/ELS": "anything else",
 "TPHO*/WUPB": "no-one",
 "TPHO*EUR/EFT": "narrowest",
+"TPHO*TS": "knots",
 "TPHO/W*UPBS": "no one's",
 "TPHO/WUPB": "no one",
 "TPHOBG/*ER": "knocker",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8470,7 +8470,7 @@
 "SAOELS": "seals",
 "SRAOEPL/EPBS": "vehemence",
 "KHAP/HRAPB": "chaplain",
-"TPHO*T/-S": "knots",
+"TPHO*TS": "knots",
 "WAEUL": "wail",
 "TPHAOEL": "kneel",
 "UPB/HRAOEULG": "unlikely",


### PR DESCRIPTION
This PR proposes to add a `TPHO*TS` condensed stroke for "knots", and have the Gutenberg dictionary prefer it over the two stroke equivalent.