### PR TITLE
Add `O*ERD/A*U` AU outline for "odour", based on `O*ERD` for "odor"

### DIFF
--- a/dictionaries/dict-en-AU-with-extra-stroke.json
+++ b/dictionaries/dict-en-AU-with-extra-stroke.json
@@ -822,6 +822,7 @@
 "KWROG/URT/A*U": "yoghurt",
 "KWROR/A*U": "{^iour}",
 "O*/PHAOET/*ER/A*U": "{^-o-metre}",
+"O*ERD/A*U": "odour",
 "O*ERT/PAOED/EUBG/A*U": "orthopaedic",
 "O*EUPLD/A*U": "edoema",
 "O*EURD/A*U": "odour",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8574,7 +8574,7 @@
 "STRA*EUT": "strait",
 "SAPB/KWEUPB": "sanguine",
 "KORDZ": "cords",
-"O*EURD/A*U": "odour",
+"O*ERD/A*U": "odour",
 "TROUT": "trout",
 "PAEUFT": "paste",
 "REGT": "regularity",


### PR DESCRIPTION
This PR proposes to add an `O*ERD/A*U` AU outline for "odour", based on the `O*ERD` outline for "odor", and have the Gutenberg dictionary prefer it.