### PR TITLE
Change fingerspelled names to outlines

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -22891,6 +22891,7 @@
 "HEPB/PEBGD": "henpecked",
 "HEPB/R*EU": "Henri",
 "HEPB/REU": "Henry",
+"HEPB/RET/TA": "Henrietta",
 "HEPB/SEU": "Hennessey",
 "HEPB/SO*PB": "Henson",
 "HEPB/TKEBG/SEUL/AB/EUBG": "hendecasyllabic",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8644,7 +8644,7 @@
 "POPBD/ERD": "pondered",
 "TPREUPBG": "fringe",
 "R*/A*/*EU/PH*/*E/TPH*/T*": "raiment",
-"H*P/*E/TPH*/R*/*EU/*E/T*/T*/A*": "Henrietta",
+"HEPB/RET/TA": "Henrietta",
 "WELG/TOPB": "Wellington",
 "TPOER/PHAPB": "foreman",
 "TPAET": "feat",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8816,7 +8816,7 @@
 "TOEPB/KWREU": "Tony",
 "KAL/KUT/TA": "Calcutta",
 "R*/*E": "re",
-"H*P/O*/HR*/T*": "Holt",
+"HOLT/A*U": "Holt",
 "SKOL": "psychological",
 "KOPB/STAPB/SEU": "constancy",
 "PHEUS/AOUDZ": "misunderstood",


### PR DESCRIPTION
This PR proposes to:

- Add the Plover `HEPB/RET/TA` outline for "Henrietta", and have the Gutenberg dictionary prefer it over fingerspelling
- Have the Gutenberg dictionary prefer the current AU dictionary outline of `HOLT/A*U` over fingerspelling