### PR TITLE
Mark `TPWREUFPL` outline for "organism" as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -1012,6 +1012,7 @@
 "TPWRAP/*L/-G": "grappling",
 "TPWRAPBD/PHOER": "grandmother",
 "TPWRAPL": "gram",
+"TPWREUFPL": "organism",
 "TPWREUL/HRA": "gorilla",
 "TRA*PBS": "trance",
 "TRAELS": "paralysis",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -131888,7 +131888,6 @@
 "TPWRERB/PHA*PB": "freshman",
 "TPWREU": "bring it",
 "TPWREUF/HROUS": "frivolous",
-"TPWREUFPL": "organism",
 "TPWUFR": "buffer",
 "TPWUT": "but it",
 "TR": "interest",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8936,7 +8936,7 @@
 "P*PL": "p.m.",
 "PWARBG/-G": "barking",
 "PWOUR": "bower",
-"TPWREUFPL": "organism",
+"TKPWREUFPL": "organism",
 "UPB/EUPB/TEL/SKWREUBL": "unintelligible",
 "EPL/TPAT/EUBG": "emphatic",
 "KROEURG": "occurring",


### PR DESCRIPTION
This PR proposes to mark the `TPWREUFPL` outline for "organism" as a mis-stroke due to missing the `K` stroke in the `TKPW` "g" sound. As a result of this, it proposes to also have the Gutenberg dictionary prefer `TKPWREUFPL` for "organism".