### PR TITLE
Uppercase outline for "ESP" in Gutenberg dictionary.

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -238,7 +238,6 @@
 "EPL/PWAES/-S": "embassies",
 "ER/RAGS": "erration",
 "ERB/AEURPL": "herbarium",
-"ERBGS/S*P": "esp",
 "ERPB/EFT/-PBS": "earnestness",
 "ETD/-G": "editing",
 "EU/TP-PL/*E/TP-PL": "i.e.",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8323,7 +8323,7 @@
 "KOER": "correspond",
 "TKE/TAEUPB": "detain",
 "TK*EU/-S": "dis",
-"ERBGS/S*P": "esp",
+"ERBGS/S*P": "ESP",
 "TERP": "interpret",
 "SRAOEPLT": "vehement",
 "SOED/A": "soda",


### PR DESCRIPTION
Fixes #447.