### PR TITLE
Change Gutenberg outlines with `-TSZ`

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -781,6 +781,7 @@
 "PHEUZ/TRUFT": "mistrust",
 "PHO*EU/SEUPB": "myosin",
 "PHO*UT/-FL": "mouthful",
+"PHO*UT/-S": "mouths",
 "PHOEUFRT/-S": "mysteries",
 "PHOS/-S": "mosses",
 "PHOS/S*E": "mosses",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8971,7 +8971,7 @@
 "EL/HREUS": "Ellis",
 "TPREUG/A*T": "frigate",
 "SPOT/-D": "spotted",
-"TOPLTSZ": "atoms",
+"AT/OPLS": "atoms",
 "KUFRBS": "curves",
 "AOUT/HRET": "outlet",
 "ROEPB/KWROUS": "erroneous",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -5109,7 +5109,7 @@
 "HRA*": "Louisiana",
 "TPARPL/ERS": "farmers",
 "WAOEULD/HREU": "wildly",
-"PHO*UTSZ": "mouths",
+"PHO*UT/-S": "mouths",
 "KARPT": "carpet",
 "SAD/-PBS": "sadness",
 "KUFT/PHAER": "customary",


### PR DESCRIPTION
This PR proposes to change the Gutenberg outlines for:

- "atoms" to `AT/OPLS`
- "mouths" to a new condensed stroke `PHO*UT/-S`

because of the high difficulty in stroking `-TSZ` without also hitting `D`.

There are many more outlines in `dict.json` that end in `-TSZ`, but these are the only two I could find in the Gutenberg dictionary.