### PR TITLE
Add Plover `HEFPL` outline for "helpful" and have the Gutenberg prefer it.

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -22770,6 +22770,7 @@
 "HEFPBL": "heavenly",
 "HEFPBS": "heavens",
 "HEFPD": "head{.}",
+"HEFPL": "helpful",
 "HEFR": "heifer",
 "HEFRP": "hemp",
 "HEFRPB": "Hersh",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8966,7 +8966,7 @@
 "TKEUS/ERPBD": "discerned",
 "POURL/HREU": "powerfully",
 "PHEUFP/EL": "Mitchell",
-"H*EFL": "helpful",
+"HEFPL": "helpful",
 "PER/SEUFT": "persist",
 "EL/HREUS": "Ellis",
 "TPREUG/A*T": "frigate",


### PR DESCRIPTION
This PR proposes to add the Plover `HEFPL` outline for "helpful", and have the Gutenberg dictionary prefer it over the current asterisked `H*EFL`.