### PR TITLE
Mark `"AOUFRTS": "University"` as a mis-stroke as `AOUFRTS` outputs "universities"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -95,6 +95,7 @@
 "AOU/HREUS/ES": "Ulysses",
 "AOU/HREUS/EUS": "Ulysses",
 "AOUFRL/PRUBGT/KOED": "Universal Product Code",
+"AOUFRTS": "University",
 "AOUR/PAOEB": "European",
 "APB/AEUGD": "an agent",
 "APB/TAOEU": "{anti^}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -8818,7 +8818,7 @@
 "AOUFRT/-F/TPRAPBS": "University of France",
 "AOUFRT/ALT": "universality",
 "AOUFRT/THAS": "universities that",
-"AOUFRTS": "University",
+"AOUFRTS": "universities",
 "AOUFS": "uses",
 "AOUFT": "out of",
 "AOUFTS": "uveitis",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9147,7 +9147,7 @@
 "EBGS/TAPBT": "extant",
 "PWOE/HAOEPL/KWRA": "Bohemia",
 "PHURPBGD": "misunderstanding",
-"AO*UFRTS": "universities",
+"AOUFRTS": "universities",
 "TKEBGS/TERT": "dexterity",
 "RAG": "rag",
 "EUPB/SEP/-BL": "inseparable",


### PR DESCRIPTION
This PR proposes to mark `"AOUFRTS": "University"` as a mis-stroke as `AOUFRTS` outputs "universities" in Plover.

As a result of this, it also proposes to have the Gutenberg dictionary prefer the `AOUFRTS` outline for "universities" over `AO*UFRTS` (which is incorrect anyway as it outputs capitalised "Universities").