### PR TITLE
Change non-Plover outlines to fingerspelling.

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -759,7 +759,6 @@
 "PHAPBLG/STEU/AES": "majesty's",
 "PHAR/AOE/TOE": "marito",
 "PHAR/HRAOE/*PB": "Marleen",
-"PHAS/TP-PL": "Mass.",
 "PHEL/OE/*ER": "mellower",
 "PHEL/TKEU/-S": "melodies",
 "PHEPB/EUPBG/KWROE/PHA": "meningioma",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9221,7 +9221,7 @@
 "TEUPLD/TEU": "timidity",
 "SOL/A*R": "solar",
 "HART/-LS": "heartless",
-"THOPLS/O*PB": "Thomson",
+"T*P/H*/O*/PH*/S*/O*/TPH*": "Thomson",
 "PHAT": "mat",
 "SHUPB": "shun",
 "RAEUD": "raid",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9764,7 +9764,7 @@
 "HROEPB/SOPL": "lonesome",
 "PHAPBD": "manned",
 "UPB/ARPLD": "unarmed",
-"WA*FT": "wast",
+"W*/A*/S*/T*": "wast",
 "TPROG": "frog",
 "TWEPBT/AET": "twenty-eight",
 "UPB/SKRAOUP/HRUS": "unscrupulous",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9625,7 +9625,7 @@
 "WEL/-BG": "well-being",
 "WEUPB/STOPB": "Winston",
 "ORD/TPHAPBS/-S": "ordinances",
-"KA*T/R*EUPB": "Catharine",
+"K*P/A*/T*/H*/A*/R*/*EU/TPH*/*E": "Catharine",
 "TPEFL": "effectively",
 "PHEUGS/-S": "missions",
 "STAUBG": "stalk",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9900,7 +9900,7 @@
 "WAOL/EPB/A*U": "woollen",
 "HRAOEUT/-PBS": "lightness",
 "PWEUT/-PB": "bitten",
-"A*UBGS": "aux",
+"A*/*U/KP*": "aux",
 "TOL/RAEUGS": "toleration",
 "HRAOU/KHA": "Lucia",
 "SKAR": "scar",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9519,7 +9519,7 @@
 "SOEULD": "soiled",
 "TP*EULD": "fiddle",
 "TPAOBL": "football",
-"AOEU/SA*EU/KWRA": "Isaiah",
+"*EUP/S*/A*/*EU/A*/H*": "Isaiah",
 "PARP": "partnership",
 "T-PB/WAEUGS": "continuation",
 "PAOEUPB/AOER": "pioneer",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9655,7 +9655,7 @@
 "TKOEFR": "Dover",
 "APL/PWURB": "ambush",
 "-FR/PHO*R": "evermore",
-"PHAS/TP-PL": "Mass.",
+"PH*P/A*/S*/S*/TP-PL": "Mass.",
 "PWHROT": "blot",
 "TPHAOBG": "nook",
 "KR*/*E/R*/TK*/*U/R*/*E": "verdure",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9685,7 +9685,7 @@
 "PWRAEUS": "brace",
 "KWERTS": "converts",
 "TKE/TEFT/-BL": "detestable",
-"EU/HR-F/*U": "143",
+"1/4/3": "143",
 "A/PWAPBD/OPBG": "abandoning",
 "S*P/O*/PH*/*E/R*/S*/*E/T*": "Somerset",
 "WAEBG/HREU": "weakly",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9986,7 +9986,7 @@
 "WAEBG/*EPB": "weaken",
 "TPOEL/KWROE": "folio",
 "STKPHEUS/A*L": "dismissal",
-"KWAO*E": "quay",
+"KW*/*U/A*/KWR*": "quay",
 "EPB/KHAPBT/-G": "enchanting",
 "HAOEF": "heave",
 "PAOUR/TPAOEUD": "purified",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9588,7 +9588,7 @@
 "PAUL/KWRA": "Paula",
 "EUPB/KORPD": "incorporated",
 "PHUZ/*L": "muzzle",
-"RAO*UB/*EPB": "Reuben",
+"R*P/*E/*U/PW*/*E/TPH*": "Reuben",
 "KHRUS/TERS": "clusters",
 "SRAFL": "valve",
 "KPELG": "compelling",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9500,7 +9500,7 @@
 "SOL": "sol",
 "KAUPB/SRAEUG": "conveying",
 "A/PWAPBD/*PLT": "abandonment",
-"PHA*EPB": "mane",
+"PH*/A*/TPH*/*E": "mane",
 "TEUPBG": "tinge",
 "PWREUPL": "brim",
 "TPOER/TPHAOPB": "forenoon",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9927,7 +9927,7 @@
 "SPEBG": "speck",
 "PWEUFBGT": "biscuit",
 "AEPT/KWROPB": "appellation",
-"TKPW*PD": "GDP",
+"TKPW*P/TK*P/P*P": "GDP",
 "REFRBS": "reserves",
 "UPB/KAO*UT": "uncouth",
 "PWEUFRPB": "birch",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9945,7 +9945,7 @@
 "KWOE/TAEUGS/-S": "quotations",
 "TPREPBD/HR*EUPBS": "friendliness",
 "HREUB/RAEL": "liberally",
-"TRA*PBS": "trance",
+"T*/R*/A*/TPH*/KR*/*E": "trance",
 "UPB/TRAOU": "untrue",
 "RE/SKWREBGS": "rejection",
 "TKPWRAEUGT": "grating",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9908,7 +9908,7 @@
 "SREFT/-D": "vested",
 "A/TPEUPBT": "affinity",
 "KAR/HROE": "Carlo",
-"SO*US": "sous",
+"S*/O*/*U/S*": "sous",
 "PEPB/TEPBT": "penitent",
 "SEUFRP/SOPB": "Simpson",
 "A/PWAOEUD/-G": "abiding",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9912,7 +9912,7 @@
 "PEPB/TEPBT": "penitent",
 "SEUFRP/SOPB": "Simpson",
 "A/PWAOEUD/-G": "abiding",
-"*URP/KRA*": "CA",
+"KR*P/A*P": "CA",
 "EUPL/PHORL": "immoral",
 "TKEUS/HOPB/EFT": "dishonest",
 "KWRAUPB/-G": "yawning",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9920,7 +9920,7 @@
 "S*UPLT": "supplement",
 "WHEURL/WEUPBD": "whirlwind",
 "KHRARB": "clash",
-"T*ERPBS": "Terence",
+"T*P/*E/R*/*E/TPH*/KR*/*E": "Terence",
 "HRAPLT/-BL": "lamentable",
 "PWEPB/ET": "Bennett",
 "TPA*RT/-G": "farthing",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9759,7 +9759,7 @@
 "AOE/PHERPBLG": "emerge",
 "PEFRPB": "perch",
 "TPHRAFBG": "flask",
-"KA/KWRA": "KA",
+"K*P/A*P": "KA",
 "KREU/PHA*PB": "countryman",
 "HROEPB/SOPL": "lonesome",
 "PHAPBD": "manned",


### PR DESCRIPTION
The current outline for "Thomson", `THOPLS/O*PB`, outputs "Thomason". There is no other named Plover entry for "Thomson", so this PR proposes to change the entry to fingerspelling in lieu of any other potential condensed stroke being found/created.