### PR TITLE
Mark `TPHOEGT` outline for "next to" as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -957,6 +957,7 @@
 "TPHER/*FS": "nerves",
 "TPHO*RBG/HART/SOEGS/TPHR-RB": "New York Heart Association",
 "TPHOEG/-S": "notions",
+"TPHOEGT": "next to",
 "TPHRAPBG/HREU": "frankly",
 "TPHRAPBG/HREUPB": "Franklin",
 "TPORBLT": "format",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -127913,7 +127913,7 @@
 "TPHOEG": "knowing",
 "TPHOEG/HREU": "knowingly",
 "TPHOEGS": "notion",
-"TPHOEGT": "next to",
+"TPHOEGT": "noting",
 "TPHOEL": "knoll",
 "TPHOEL/A*PB": "Nolan",
 "TPHOELS": "necessarily",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9317,7 +9317,7 @@
 "SKWRERPL": "germ",
 "PROEFL": "profile",
 "PROEUFDZ": "provides",
-"TPHO*EGT": "noting",
+"TPHOEGT": "noting",
 "TKORD/-D": "disordered",
 "PHEPB/AS/-G": "menacing",
 "HAOEUT/*EPBD": "heightened",


### PR DESCRIPTION
This PR proposes to mark the `TPHOEGT` outline for "next to" as a mis-stroke, as it now outputs "noting".

Also, have the Gutenberg dictionary prefer `TPHOEGT` for "noting" over the asterisked version `TPHO*EGT`.