### PR TITLE
Give Gutenberg outline entry for "savings" a long "ā" vowel

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9461,7 +9461,7 @@
 "SREU/KAR": "vicar",
 "TPHO*E/WEL": "Noel",
 "AT/TEUBG": "attic",
-"SAFGS": "savings",
+"SAEUFGS": "savings",
 "A/TPEURPL/TEUF": "affirmative",
 "EUL/-S": "ills",
 "PAEUBGS/-S": "applications",


### PR DESCRIPTION
This PR proposes to give the Gutenberg outline entry for "savings" a long "ā" vowel, `SAEUFGS`, to more accurately match its word pronunciation.