### PR TITLE
Change Gutenberg outline for "explicit" to Plover `EBGS/PHREUFT` outline

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9617,7 +9617,7 @@
 "UPB/HROBGD": "unlocked",
 "TPOER/TOLD": "foretold",
 "AUPL/EUBG": "automatic",
-"SKHREUFT": "explicit",
+"EBGS/PHREUFT": "explicit",
 "EUPBD/HREPBT": "indolent",
 "PHAEUTS": "mates",
 "ART/-FL": "artful",


### PR DESCRIPTION
This PR proposes to change the Gutenberg outline for "explicit" to the Plover `EBGS/PHREUFT` outline since `SKHREUFT` is a private Di dictionary entry.