### PR TITLE
Change Gutenberg dictionary outline for "laurel" to `HRAU/REL` as

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9672,7 +9672,7 @@
 "HAEU/REU": "hairy",
 "TPWHO*ES": "northwest",
 "TKABLD": "disabled",
-"HRAURL": "laurel",
+"HRAU/REL": "laurel",
 "PRES/TO*PB": "Preston",
 "AR/TKPWAPBT": "arrogant",
 "HURTS": "hurts",


### PR DESCRIPTION
This PR proposes to change the Gutenberg dictionary outline for "laurel" to `HRAU/REL`, as `HRAURL` outputs the capitalised name "Laurel".