### PR TITLE
Add Plover `TRERPL` outline for "tremor".

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -133328,6 +133328,7 @@
 "TRERB/UR": "treasure",
 "TRERD": "interpreted",
 "TRERG": "interpreting",
+"TRERPL": "tremor",
 "TRERS": "interpreters",
 "TRERT": "{tetra^}",
 "TRES": "tress",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9691,7 +9691,7 @@
 "WAEBG/HREU": "weakly",
 "KHRO*ET": "clothe",
 "SKWREPL": "gem",
-"TEPL/O*R": "tremor",
+"TRERPL": "tremor",
 "SUR/SRAEUG": "surveying",
 "SRAEURB": "variable",
 "APB/SRERS/REU": "anniversary",


### PR DESCRIPTION
This PR proposes to add the Plover `TRERPL` outline for "tremor" to `dict.json`, and have the Gutenberg dictionary prefer it.