### PR TITLE
Change vowel sound in Gutenberg outline for "believer" to be a long "ē".

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9704,7 +9704,7 @@
 "TPRAOEZ/-G": "freezing",
 "HAOED/-LS": "heedless",
 "SEPBT/REU": "sentry",
-"PWHREFR": "believer",
+"PWHRAOEFR": "believer",
 "RAPL": "ram",
 "ROE/-G": "rowing",
 "TPHEPBLGS": "negligence",


### PR DESCRIPTION
This PR proposes to change the vowel sound in Gutenberg outline for "believer" to be a long "ē" to more accurately match word pronunciation.