### PR TITLE
Add single-stroke Plover `KA*FLS` outline for "calves"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -29696,6 +29696,7 @@
 "KA*FL/HRAOER": "cavalier",
 "KA*FL/KAEUD": "cavalcade",
 "KA*FL/REU": "cavalry",
+"KA*FLS": "calves",
 "KA*FP": "capture",
 "KA*FPD": "captured",
 "KA*FPG": "capturing",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9998,5 +9998,5 @@
 "KAOPGS": "cooperation",
 "SKWEL": "sequel",
 "WEFRPB": "wench",
-"KA*F/-S": "calves"
+"KA*FLS": "calves"
 }


### PR DESCRIPTION
This PR proposes to add the single-stroke Plover `KA*FLS` outline for "calves" to `dict.json`, and have the Gutenberg dictionary prefer it.