### PR TITLE
Change outline for "weaving" used in the Gutenberg dictionary to have a long "ē" vowel.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9860,7 +9860,7 @@
 "RE/PRAOF": "reproof",
 "KWRAEL": "Yale",
 "KPWAOEUPBG": "combining",
-"WEFG": "weaving",
+"WAOEFG": "weaving",
 "ERPBGS": "earnings",
 "HAPL/PWURG": "Hamburg",
 "EUPB/TKAORS": "indoors",


### PR DESCRIPTION
This PR proposes to change the outline for "weaving" used in the Gutenberg dictionary to have a long "ē" vowel (`WAOEFG`) to more accurately reflect word pronunciation.