### PR TITLE
Fix entry for `PO` outline as it outputs lowercase "po" and not capitalised "Po".

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -9431,7 +9431,7 @@
 "SKWRAEU": "jay",
 "RE/PULS/EUF": "repulsive",
 "TPRAEU": "fray",
-"PO": "Po",
+"PO": "po",
 "TPHOPL/TPHAEUGS": "nomination",
 "KAUPB/KHRAOUS/EUF": "conclusive",
 "PAES/-BL": "peaceable",


### PR DESCRIPTION
Following on from the discussion in #465, this PR proposes to fix entry for the `PO` outline ,as it outputs lowercase "po" and not capitalised "Po" (and because "po" lowercased is likely the entry that was intended for the Gutenberg dictionary).

Fixes #465.