### PR TITLE
Add Plover outline `AS` for "as"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -118,6 +118,7 @@
 "APL/KAEUS/*EUB": "amikacin",
 "AR/PHOEPB/KWROUS": "harmonious",
 "ARBG/TPAOEUS": "sacrifice",
+"AS": "{^s}{a^}",
 "AS/PREUB": "aspirin",
 "AS/PREUP": "aspirin",
 "AT/TERPB": "pattern",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -11397,7 +11397,7 @@
 "ART/WORBG": "artwork",
 "ARTS": "arts",
 "ARTS/TPHAL": "artisanal",
-"AS": "{^s}{a^}",
+"AS": "as",
 "AS/*ER/TAEUPB": "ascertain",
 "AS/-P": "asp",
 "AS/-PS": "asps",

--- a/dictionaries/top-100-words.json
+++ b/dictionaries/top-100-words.json
@@ -13,7 +13,7 @@
 "W": "with",
 "S": "is",
 "TPOR": "for",
-"AZ": "as",
+"AS": "as",
 "H": "had",
 "U": "you",
 "TPHOT": "not",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -13,7 +13,7 @@
 "W": "with",
 "S": "is",
 "TPOR": "for",
-"AZ": "as",
+"AS": "as",
 "H": "had",
 "U": "you",
 "TPHOT": "not",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -13,7 +13,7 @@
 "W": "with",
 "S": "is",
 "TPOR": "for",
-"AZ": "as",
+"AS": "as",
 "H": "had",
 "U": "you",
 "TPHOT": "not",

--- a/dictionaries/top-200-words-spoken-on-tv.json
+++ b/dictionaries/top-200-words-spoken-on-tv.json
@@ -69,7 +69,7 @@
 "TKPWAOD": "good",
 "THE": "they",
 "R-L": "really",
-"AZ": "as",
+"AS": "as",
 "WO": "would",
 "HRAOBG": "look",
 "WHEPB": "when",


### PR DESCRIPTION
This PR proposes to add the Plover outline `AS` for "as" to `dict.json`, and prefer it in all the other top-x dictionaries over `AZ` due to not having to reach for the `Z` key.