### PR TITLE
Add Plover `TP*EL` outline for "fellow"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -121723,6 +121723,7 @@
 "TP*EFRB/EUD": "fervid",
 "TP*EFRB/SROR": "fervor",
 "TP*EFT/*ER": "feather",
+"TP*EL": "fellow",
 "TP*EPB/EUG": "pfennig",
 "TP*EPB/TPHEUG": "pfennig",
 "TP*EPL/TAOUR": "temperature",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -606,7 +606,7 @@
 "EPS": "especially",
 "TKPWRAERT": "greater",
 "KWRO*URS": "yourself",
-"TPO*EUL": "fellow",
+"TP*EL": "fellow",
 "PWAER": "bear",
 "P-PB": "opinion",
 "WOEUPBD": "window",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -606,7 +606,7 @@
 "EPS": "especially",
 "TKPWRAERT": "greater",
 "KWRO*URS": "yourself",
-"TPO*EUL": "fellow",
+"TP*EL": "fellow",
 "PWAER": "bear",
 "P-PB": "opinion",
 "WOEUPBD": "window",


### PR DESCRIPTION
This PR proposes to add the Plover `TP*EL` outline for "fellow" and have the top-x dictionaries prefer it.