### PR TITLE
Remove condensed stroke for "civilisation" as it outputs "civil isation"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1170,7 +1170,6 @@
 "SELTD": "settled",
 "SELTS": "settles",
 "SER/PHOEPB/-S": "ceremonies",
-"SEUFL/*EU/SAEUGS": "civilisation",
 "SEUFL/HREU": "civilly",
 "SEUFLT/-S": "civilities",
 "SEUG/TPAOEU/-S": "signifies",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7233,7 +7233,7 @@
 "PROFG": "proving",
 "PWEPBL/SREPBS": "benevolence",
 "PWRUS/ELS": "Brussels",
-"SEUFL/*EU/SAEUGS": "civilisation",
+"SEUFLGS/A*U": "civilisation",
 "PHOUPBT/-G": "mounting",
 "STKAOEURG": "desiring",
 "RURBS": "rushes",


### PR DESCRIPTION
This PR proposes to remove the condensed stroke for "civilisation" as it outputs "civil isation".

As a result of this, have the Gutenberg dictionary prefer the AU dictionary outline `SEUFLGS/A*U`.