### PR TITLE
Add "lustre" AU stroke based on current Plover `HRUFRT` outline for "luster"

### DIFF
--- a/dictionaries/dict-en-AU-with-extra-stroke.json
+++ b/dictionaries/dict-en-AU-with-extra-stroke.json
@@ -556,6 +556,7 @@
 "HROL/HREU/A*U": "lolly",
 "HROPBLG/*EPLT": "lodgement",
 "HROPBLG/*PLT/A*U": "lodgement",
+"HRUFRT/A*U": "lustre",
 "HRUPL/TPHUPL/A*U": "aluminium",
 "HRUS/TER/A*U": "lustre",
 "K*EUG/TKPWRAPL/A*U": "kilogramme",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -7598,7 +7598,7 @@
 "TEPBD/SEUS": "tendencies",
 "KRAOEPBT": "concrete",
 "REPBLT": "resident",
-"HRUS/TER/A*U": "lustre",
+"HRUFRT/A*U": "lustre",
 "HUL": "hull",
 "OPL/TPHOUS": "ominous",
 "AUFR/PWAO*RD": "overboard",


### PR DESCRIPTION
This PR proposes to add a new "lustre" AU stroke based on current Plover single-stroke `HRUFRT` outline for "luster", and have the Gutenberg dictionary prefer it.