### PR TITLE
Add `HO*RPB/A*U` AU stroke for "honour" based on Plover `HO*RPB` outline.

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -325,7 +325,6 @@
 "H*/A*/TPH*/TK*/S*/O*/PH*/*E/S*/T*": "handsomest",
 "H*/O*/*U/S*/*E/PH*/A*/*EU/TK*": "housemaid",
 "H*/O*/*U/S*/*E/PH*/A*/*EU/TK*/S*": "housemaids",
-"H*/O*/TPH*/O*/*U/R*": "honour",
 "H*ELT/-FL": "healthful",
 "H*ELT/-FL/-PBS": "healthfulness",
 "H*ERLD/EUBG": "heraldic",

--- a/dictionaries/dict-en-AU-with-extra-stroke.json
+++ b/dictionaries/dict-en-AU-with-extra-stroke.json
@@ -437,6 +437,7 @@
 "HEUP/TPHOE/TAOEUZ/A*U": "hypnotise",
 "HEURT/A*U": "litre",
 "HO*PB/RABL/A*U": "Honourable",
+"HO*RPB/A*U": "honour",
 "HO*URPB/A*U": "honour",
 "HO*URPBS/A*U": "honours",
 "HO/PHOPBLG/TPHAOEUZ/A*U": "homogenise",

--- a/dictionaries/top-1000-words.json
+++ b/dictionaries/top-1000-words.json
@@ -844,7 +844,7 @@
 "KR-BL": "considerable",
 "KR*": "c",
 "PWROEBG": "broke",
-"H*/O*/TPH*/O*/*U/R*": "honour",
+"HO*RPB/A*U": "honour",
 "SEFPB": "seven",
 "PRAOEUFT": "private",
 "SEUT": "sit",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -844,7 +844,7 @@
 "KR-BL": "considerable",
 "KR*": "c",
 "PWROEBG": "broke",
-"H*/O*/TPH*/O*/*U/R*": "honour",
+"HO*RPB/A*U": "honour",
 "SEFPB": "seven",
 "PRAOEUFT": "private",
 "SEUT": "sit",


### PR DESCRIPTION
This PR proposes to add a `HO*RPB/A*U` AU stroke for "honour" based on the Plover `HO*RPB` outline for "honor", and have the other dictionaries prefer it. As a result of this, also remove fingerspelling condensed stroke for "honour" as it would not be used anymore.