### PR TITLE
Fix "they have" outline typo

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1357,7 +1357,7 @@
 "THAPB/K-FL/-PBS": "thankfulness",
 "THAPBG/-FL": "thankful",
 "THE/R": "they are",
-"THE/S-R": "they have",
+"THE/SR": "they have",
 "THEURD/HREU": "thirdly",
 "THEURT/H-PB/SEUBGS": "thirty-six",
 "THEURT/H-PB/TWO": "thirty-two",


### PR DESCRIPTION
`THE/S-R` outputs "they Sr.", so this PR proposes to change the "they have" outline to the correct `THE/SR`.