### PR TITLE
Change `AES/ES` from "'s" to "{^'s}"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -67,6 +67,7 @@
 "A/SPWAOUS": "abuse",
 "ABG/RAEUT": "accurate",
 "AEFD": "evidence",
+"AES/ES": "'s",
 "AEUR/TEU": "{^arity}",
 "AFG": "average",
 "AG/ROUPBD": "{^ing}{^a}",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -5081,7 +5081,7 @@
 "AERT/SKHROZ": "arteriosclerosis",
 "AERT/TPABGT": "artifact",
 "AES": "{^'s}",
-"AES/ES": "'s",
+"AES/ES": "{^'s}",
 "AES/ES/SAEU": "{^'s essay}",
 "AES/THET/EUBG": "aesthetic",
 "AES/THET/EUBG/HREU": "aesthetically",


### PR DESCRIPTION
Plover says `AES/ES` is another outline for "{^'s}", and not "'s", so this PR proposes to mark the latter as a mis-stroke and fix the entry in `dict.json`.