### PR TITLE
Add `HOR/TKEFRBZ` condensed stroke for "hors d'oeuvres"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -395,6 +395,7 @@
 "HOEFTD": "hosted",
 "HOEL/-D": "holed",
 "HOEUL/-PBS": "holiness",
+"HOR/TKEFRBZ": "hors d'oeuvres",
 "HORS/PH*EPB": "horsemen",
 "HORS/PWA*BG": "horseback",
 "HORS/WO*PL": "horsewoman",


### PR DESCRIPTION
This PR proposes to add a `"HOR/TKEFRBZ": "hors d'oeuvres"` condensed stroke to the word's already ample collection of outlines.