### PR TITLE
Add `TPHAEPLS` condensed stroke for "enemies"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1589,6 +1589,7 @@
 "TPH/KPAEUPBG": "in exchange",
 "TPHA*EUGS/-S": "nations",
 "TPHA*EUGSZ": "nations",
+"TPHAEPLS": "enemies",
 "TPHAEUB/A*U/HREU": "neighbourly",
 "TPHAEUPL/-G": "naming",
 "TPHAO*ELD/WO*RBG": "needlework",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -1329,7 +1329,7 @@
 "PREUPBS": "prince",
 "PERPLT/-D": "permitted",
 "TKPWROUP": "group",
-"EPB/PHEUS": "enemies",
+"TPHAEPLS": "enemies",
 "ROBT": "Robert",
 "PHRAEUD": "played",
 "THROUT": "throughout",


### PR DESCRIPTION
This PR proposes to add a `TPHAEPLS` condensed stroke for "enemies" based on the `TPHAEPL` Plover outline for "enemy", and have the Gutenberg dictionary prefer it.