### PR TITLE
Add `ARBGTS` condensed stroke for "actors".

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -145,6 +145,7 @@
 "APBLG/TAEUTD": "agitated",
 "AR/PHOUR/*ER": "armourer",
 "AR/PHOUR/*ER/AES": "armourer's",
+"ARBGTS": "actors",
 "ARPL/HR*ET": "armlet",
 "ART/-LS": "artless",
 "AUBG/WARD/-PBS": "awkwardness",


### PR DESCRIPTION
This PR proposes to add an `ARBGTS` condensed stroke for "actors". `dict.json` and Plover already have an existing `A*RBGTS` entry for "actors", but it seems that the un-asterisked version works as well.