### PR TITLE
Change Gutenberg entry for "eagle" from `AOEG/*L` to `AOEG/-L`.

### DIFF
--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -4714,7 +4714,7 @@
 "RAO*EP": "repair",
 "TPEUFT": "fist",
 "REBGT": "recollect",
-"AOEG/*L": "eagle",
+"AOEG/-L": "eagle",
 "HOPB/RABL": "honorable",
 "SEUG": "significant",
 "PWAEURPB": "barren",


### PR DESCRIPTION
This PR proposes to change the Gutenberg entry for "eagle" from `AOEG/*L` to `AOEG/-L`, simply because it's one less key to press.