### PR TITLE
Mark `WAFR` for "wafer" as a mis-stroke as it outputs "waver".

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -1113,6 +1113,7 @@
 "WABG/APBD/TPO*RT": "back and forth",
 "WAFBG": "watching",
 "WAFBGT/PWAUL": "basketball",
+"WAFR": "wafer",
 "WAOEPBG": "winning",
 "WAORD/WAUBG": "boardwalk",
 "WHAOELD": "withhold",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -136229,7 +136229,7 @@
 "WAFPD": "watched",
 "WAFPG": "watching",
 "WAFPS": "watches",
-"WAFR": "wafer",
+"WAFR": "waver",
 "WAFR/-D": "wavered",
 "WAFR/-G": "wavering",
 "WAFR/-S": "wavers",


### PR DESCRIPTION
This PR proposes to mark `WAFR` outline for "wafer" as a mis-stroke as it outputs "waver", and change the existing `WAFR` dictionary entry to the correct "waver".