### PR TITLE
Add `SRERPBTD` condensed stroke for "ventured" and have the Gutenberg

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1283,6 +1283,7 @@
 "SREBGS/-S": "vexes",
 "SREBGS/S*E": "vexes",
 "SREFT/-PLTS": "vestments",
+"SRERPBTD": "ventured",
 "SREUFD/HREU": "vividly",
 "SREURT/WOS/TEU": "virtuosity",
 "SREURT/WOUS": "virtuous",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -3238,7 +3238,7 @@
 "SAEF": "satisfy",
 "AG/TPHEU": "agony",
 "R-PTS": "respects",
-"SREPB/KHURD": "ventured",
+"SRERPBTD": "ventured",
 "EUPL/PHRAOEUD": "implied",
 "PHA/REU/KWRA": "Maria",
 "STAOUPD": "stupid",


### PR DESCRIPTION
This PR proposes to add a single-stroke `SRERPBTD` condensed stroke for "ventured", and have the Gutenberg dictionary prefer it.