### PR TITLE
Remove initial space from "arteries" outline.

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -76712,7 +76712,7 @@
 "RARPB": "rather than",
 "RART": "artery",
 "RART/OES/US": "arteriosus",
-"RARTS": " arteries",
+"RARTS": "arteries",
 "RARTSZ": "arteries",
 "RAS/*P": "rasp",
 "RAS/*P/-S": "rasps",


### PR DESCRIPTION
This PR proposes to fix what looks like a typo in the outline for "arteries", which would seem to prevent it from being shown in Typey Type. I definitely think that `RARTS` is an easier stroke than `RARTSZ`, which is very difficult to stroke without also accidentally hitting the `D` key.