### PR TITLE
Add single-stroke `HEPBZ` condensed stroke for "hens".

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -385,6 +385,7 @@
 "HE/WAEUTS": "he waits",
 "HE/WO": "he would",
 "HEPBLGD": "hedged",
+"HEPBZ": "hens",
 "HEPT/PWEUL/KWRAER": "hepatobiliary",
 "HERDZ/PHA*PB": "herdsman",
 "HERLD/-S": "heralds",


### PR DESCRIPTION
The Typey Type exercises have the outline for "hens" listed as `HEPB/-S`, so this PR proposes to add a single-stroke condensed stroke for "hens".