### PR TITLE
Mark `STPHU` outline for "you?" as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -719,6 +719,7 @@
 "STPH": "{?}",
 "STPH*": "{?}",
 "STPHAOUG": "institution",
+"STPHU": "you?",
 "STRAPBGS": "strategies",
 "STRAPBLS": "strategies",
 "STRAPLGS": "strategies",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -102437,7 +102437,6 @@
 "STPHROPBG": "long{?}",
 "STPHRULT": "result{?}",
 "STPHRURPB": "return{?}",
-"STPHU": "you?",
 "STPHUB": "snub",
 "STPHUB/TPHOES/-D": "snub-nosed",
 "STPHUBG": "snuck",


### PR DESCRIPTION
This PR proposes to mark the `STPHU` outline for "you?" as a mis-stroke as it does not seem to exist in Plover's dictionary.