### PR TITLE
Mark `K*EF` for "contraceptive" as a mis-stroke, as Plover now outputs "Kev".

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -294,6 +294,7 @@
 "HRUFP": "clutch",
 "HULG": "hulk",
 "HUPBD/SKWRU": "Hindu",
+"K*EF": "contraceptive",
 "K-FRPL/TEU": "conformity",
 "KA/TAOED/RAL": "cathedral",
 "KAEULT": "indicate",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -29344,7 +29344,7 @@
 "K*/A*/HR*/*EU/KR*/R*/*E/TPH*": "kallikrein",
 "K*EBG": "kinetic",
 "K*EBGS": "kinetics",
-"K*EF": "contraceptive",
+"K*EF": "Kev",
 "K*EFPLGS": "conceptions",
 "K*EFPT": "concept",
 "K*EFS": "contraceptives",


### PR DESCRIPTION
This PR proposes to mark `K*EF` for "contraceptive" as a mis-stroke, as Plover now officially outputs "Kev".