### PR TITLE
Mark `TKUPB` for `"{&dun-}"` as a mis-stroke

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -913,6 +913,7 @@
 "TKROEU": "destroy",
 "TKROEUD": "destroyed",
 "TKROEUG": "destroying",
+"TKUPB": "{&dun-}",
 "TKUZ": "does",
 "TKWAOEUB": "divine",
 "TKWEPBT": "divinity",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -120567,7 +120567,7 @@
 "TKULT/TRER": "adulterer",
 "TKULTD": "adulthood",
 "TKUP/KAEUGS": "duplication",
-"TKUPB": "{&dun-}",
+"TKUPB": "dun",
 "TKUPB/-BG": "dunk",
 "TKUPB/-BGD": "dunked",
 "TKUPB/-BGS": "dunks",


### PR DESCRIPTION
This PR proposes to mark `TKUPB` for "{&dun-}" as a mis-stroke since Plover now specifies `TKUPB` to be simply "dun".