### PR TITLE
Add `REUPBG/*ER` condensed stroke for "ringer"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1148,6 +1148,7 @@
 "REUFP/-PBS": "richness",
 "REUFP/HREU": "richly",
 "REULG/-D": "ridiculed",
+"REUPBG/*ER": "ringer",
 "REUPL/SKWR*E": "rime",
 "ROBGS/SKP/SHOEL/-S": "rocks and shoals",
 "ROBGT/HRET/TUS": "rocket lettuce",


### PR DESCRIPTION
This PR proposes to add a `REUPBG/*ER` condensed stroke for "ringer".