### PR TITLE
Replace condensed stroke `STOR/KWREU` for "storey"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1358,7 +1358,7 @@
 "STKPHEUS/A*L": "dismissal",
 "STKPWAO*URB/-S": "extinguishes",
 "STOEBG/-D": "stoked",
-"STOR/KWREU": "storey",
+"STOR/TK-LS/KWREU": "storey",
 "STPHAEUBG/TK-LS/PWAOEPB": "snakebean",
 "STPHAL/AO*EUFD": "signalized",
 "STPHAOUGS/-S": "institutions",


### PR DESCRIPTION
Condensed stroke `STOR/KWREU` for "storey" is already a named Plover outline in `dict.json` for "story".

So, this PR proposes to change the condensed stroke entry to `STOR/TK-LS/KWREU` (I couldn't figure out anything better...).