### PR TITLE
Add `W-R/AE/TK-LS/R*/*E` condensed stroke for "where're".

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1875,6 +1875,7 @@
 "W*P/*EU/HR*/TP*/*U/HR*/HR*/KWR*": "Wilfully",
 "W*P/*EU/KR*/K*/H*/A*/PH*": "Wickham",
 "W*P/A*/R*/W*/*EU/KR*/K*": "Warwick",
+"W-R/AE/TK-LS/R*/*E": "where're",
 "W/A*L": "withal",
 "WA*R/TO*PB": "Warton",
 "WA*UR/TKROPS": "waterdrops",


### PR DESCRIPTION
This PR proposes to add a `W-R/AE/TK-LS/R*/*E` condensed stroke for "where're".

In the Homophones lesson, it's currently entered as:

https://github.com/didoesdigital/typey-type-data/blob/5cd64a568bb2d0a9dbcea42c2858a6b9d8be8120/lessons/drills/homophones/homophones.json#L958

This, as well as having spaces instead of slashes between strokes(?), outputs "where' re" with an un-needed space, so hopefully this entry fixes that.