### PR TITLE
Add Plover outline `KPEUPBS` for "existence" to `dict.json`

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -40130,6 +40130,7 @@
 "KPEUPBLG/EPB/SEU": "exigency",
 "KPEUPBLG/EPBS": "exigence",
 "KPEUPBLG/EPBT": "exigent",
+"KPEUPBS": "existence",
 "KPEUPL": "occipital",
 "KPEUPLT": "occipital",
 "KPEUPLT/A*L/EUS": "occipitalis",


### PR DESCRIPTION
This PR proposes to add the Plover outline `KPEUPBS` for "existence" to `dict.json`.

I was also considering proposing to change the top-x dictionaries preference for "existence" from the current `KPEUFS` to `KPEUPBS`: even though it's longer, I find it much easier to stroke. But, since `KPEUFS` is a fine outline, I don't think I could objectively suggest the change.