### PR TITLE
Add condensed stroke `HOUSZ` for "houses"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -426,6 +426,7 @@
 "HOT/HREU": "hotly",
 "HOT/TK-LS/HOUS": "hothouse",
 "HOUS/HOLD/*ER": "householder",
+"HOUSZ": "houses",
 "HR*/*EU/SR*/*E/HR*/*EU/*E/S*/T*": "liveliest",
 "HR*/HR*": "ll",
 "HR*/O*/*U/*EU/S*": "louis",


### PR DESCRIPTION
This PR proposes to add a condensed stroke `HOUSZ` for "houses".