### PR TITLE
Add Plover `RE/TRAOEFR` outline for "retriever"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -78626,6 +78626,7 @@
 "RE/TRAOEFBL": "retrievable",
 "RE/TRAOEFD": "retrieved",
 "RE/TRAOEFL": "retrieval",
+"RE/TRAOEFR": "retriever",
 "RE/TRAOET": "retreat",
 "RE/TRAOET/-D": "retreated",
 "RE/TRAOET/-S": "retreats",


### PR DESCRIPTION
This PR simply proposes to add the Plover `RE/TRAOEFR` outline for "retriever" to `dict.json`.