### PR TITLE
Add `TURPB/O*EFR` condensed stroke for "turnover".

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1749,6 +1749,7 @@
 "TUPBG/-D": "tongued",
 "TUPL/-BL/SKWROUPB": "tumbledown",
 "TUPL/ULT/WOUS": "tumultuous",
+"TURPB/O*EFR": "turnover",
 "TWEPBT/H-PB/AET": "twenty-eight",
 "TWEPBT/H-PB/SEUBGS": "twenty-six",
 "TWEPBT/H-PB/THRAOE": "twenty-three",


### PR DESCRIPTION
This PR proposes to add a `TURPB/O*EFR` condensed stroke for "turnover". The `TURPB/SKWROEFR` Plover outline seems a bit strange to me, to be honest, though that's probably because I'm missing a Plover theory lesson :)