### PR TITLE
Make `O*EU` outline-related changes

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -417,6 +417,7 @@
 "KWRUPB": "{un^}",
 "KWRUPBD": "{under^}",
 "KWRUS": "{^us}",
+"O*EU": "oy",
 "O*US": "{^us}",
 "O/WEPB": "Owen",
 "OBGS/SKWREB": "oxygen",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -726,6 +726,7 @@
 "O*/*E/SP-S/TP-PL": "oe.",
 "O*/*EU": "oi",
 "O*/KR*/T*": "oct",
+"O*/KWR*": "oy",
 "O*/PW*": "ob",
 "O*/PW*/S*": "obs",
 "O*/TK*": "od",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -45214,7 +45214,7 @@
 "O*ERZ": "otherwise",
 "O*ES": "{^ose}",
 "O*ET": "oath",
-"O*EU": "oy",
+"O*EU": "oi",
 "O*EU/SEUPB": "eosin",
 "O*EU/SEUPB/TP*EUL": "eosinophil",
 "O*EU/SEUPB/TP*EUL/KWRA": "eosinophilia",


### PR DESCRIPTION
The `O*EU` outline outputs "oi" in Plover, so this PR proposes to make the following changes:

- Change `dict.json` entry for `O*EU` to "oi"
- Add bad habits entry for `O*EU` as "oy"
- Add a named fingerspelled condensed stroke entry for "oy"