### PR TITLE
Add condensed stroke from Apostrophes lesson

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -474,6 +474,7 @@
 "HRERPBG/PH-GT/S-PL": "learning management system",
 "HRERPBG/SKP/SREPLT": "learning and development",
 "HRERPBG/SP-PBD/SREPLT": "learning & development",
+"HRETS/SAOUPL": "let's assume",
 "HREUFR/KWREU/-S": "liveries",
 "HREUL/KWREU/-S": "lilies",
 "HRO*ER/HA*RT": "hart",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -494,6 +494,7 @@
 "HRUF/-BL": "loveable",
 "HUPBTS/PHA*PB": "huntsman",
 "HURBD": "hushed",
+"HUSZ/AE": "husbands'",
 "K*P/*E/TPH*/*EU/HR*/W*/O*/R*/T*/H*": "Kenilworth",
 "K*P/KWR*/PH*/P*/T*/O*/TPH*": "Kympton",
 "K-FRT/-LS": "comfortless",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -448,6 +448,7 @@
 "HRAD/SKWR*E": "lade",
 "HRAEU/PWOUR/-D": "laboured",
 "HRAEU/SKWROUPB": "laydown",
+"HRAEUDZ/AE": "ladies'",
 "HRAOBG/TK-LS/SPHART": "looksmart",
 "HRAOD/*ER": "loader",
 "HRAOD/-D": "loaded",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1315,6 +1315,7 @@
 "SPAPBG/*LD": "spangled",
 "SPEURT/-LS": "spiritless",
 "SPHAOEULG/HREU": "smilingly",
+"SPHORS": "s'mores",
 "SPHROR/*ER": "explorer",
 "SPHROR/AEUGS": "exploration",
 "SPHRORD": "explored",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1194,6 +1194,7 @@
 "S-BGS/KWREU": "sexy",
 "S-FSZ": "services",
 "S-P/EUFT": "ist",
+"S-PBT/TPHES": "isn't necessary",
 "S-PBZ": "seasons",
 "SABG/-FL": "sackful",
 "SABG/-S/-FL": "sacksful",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1424,6 +1424,7 @@
 "THA/WUPB": "that one",
 "THAPB/K-FL/-PBS": "thankfulness",
 "THAPBG/-FL": "thankful",
+"THATS/SKWRUF/-T": "that's just the",
 "THE/R": "they are",
 "THE/SR": "they have",
 "THEURD/HREU": "thirdly",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -633,6 +633,7 @@
 "KPAEUPBG/-G": "exchanging",
 "KPAEUPBG/-S": "exchanges",
 "KPAEUPBGS": "exchanges",
+"KPAEUPBT/AES": "complaint's",
 "KPAL/HREU": "capitally",
 "KPARPLT/A*L/AOEUZ": "compartmentalize",
 "KPARPLT/HRAOEUZ": "compartmentalize",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -741,6 +741,7 @@
 "OEFPB/-FL": "ovenful",
 "OEPB/SEFL": "ownself",
 "OER/AES": "other's",
+"OERBGS/T-S": "oh, it's",
 "OERG/*ES": "ogress",
 "OEUFRT/PHURB/RAOPLS": "oyster mushrooms",
 "OEUR/SKWREPB/TAL": "urogenital",


### PR DESCRIPTION
This PR proposes to add some condensed strokes that have come up while I was doing the [Apostrophes Typey Type exercise](https://didoesdigital.com/typey-type/lessons/drills/apostrophes/) that reduce the outline in some way, either by characters or strokes, from what is in the Plover dictionary.