### PR TITLE
Fix outline for "gentlemen's"

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -663,6 +663,7 @@
 "SKWR-R/KWRUS": "injurious",
 "SKWRAOED": "{^ed}",
 "SKWRAOEU/SKWRAPBT/EUBG": "gigantic",
+"SKWRE/AES": "gentlemen's",
 "SKWREB/RAEUGS": "generation",
 "SKWREB/WEUPB": "genuine",
 "SKWREPB/RAEGS/-S": "generations",

--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1282,6 +1282,7 @@
 "SKWR*EL/KWREU/-S": "jellies",
 "SKWR*EPBG/*EUPBS/O*PB": "Jenkinson",
 "SKWR*EPBLT/-PBS": "gentleness",
+"SKWR*EPL/AES": "gentlemen's",
 "SKWR*P/*U/TK*/A*/H*": "Judah",
 "SKWRA*BG/A*L": "Jackal",
 "SKWRA*PL/HRA*EBG": "gentlemanlike",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -91913,7 +91913,6 @@
 "SKWRAZ/SEU": "jazzy",
 "SKWRAZ/SEU/*PBS": "jazziness",
 "SKWRE": "{^e}",
-"SKWRE/AES": "gentlemen's",
 "SKWRE/HOE/SRA": "Jehovah",
 "SKWRE/HOEF/KWRA": "Jehovah",
 "SKWRE/HOEF/KWRA/AES/W-PBS": "Jehovah's Witness",


### PR DESCRIPTION
There is no longer a named Plover outline for "gentlemen's". Therefore, this PR proposes to:

- move the original entry from `dict.json` to `bad-habits.json` (it would need to go there anyway since `SKWRE/AES` now outputs "e's"
- create a condensed stroke for "gentlemen's", using the shortest official outline for "gentlemen"