### PR TITLE
Fix outline value for `OERPBT`

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -426,6 +426,7 @@
 "OBGS/SKWREB": "oxygen",
 "OEBS/-S": "observations",
 "OELD/TPAGSD": "old-fashioned",
+"OERPBT": "ordinary, reasonable, and prudent",
 "OPL/TER": "{^ometer}",
 "OPL/TPHUS": "ominous",
 "OZ": "00",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -46818,7 +46818,7 @@
 "OERPBLD": "ordinarily",
 "OERPBLG": "original",
 "OERPBS": "owners",
-"OERPBT": "ordinary, reasonable, and prudent",
+"OERPBT": "interior",
 "OERPGS": "operation",
 "OERPT": "operate",
 "OERPT/*EUF": "operative",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -2775,7 +2775,7 @@
 "HRAPBD/-D": "landed",
 "KREUGS/-S": "Christians",
 "PAGS/-S": "passions",
-"SPWER/KWROR": "interior",
+"OERPBT": "interior",
 "SKAEURS": "scarce",
 "HRAOEULT": "lightly",
 "STKURBD": "disturbed",


### PR DESCRIPTION
Outline `OERPBT` outputs "interior", rather than "ordinary, reasonable, and prudent", therefore this PR proposes the following changes based on what issues I found while doing Typey Type's [Steno party tricks lesson](https://didoesdigital.com/typey-type/lessons/drills/steno-party-tricks/):

- Mark `OERPBT` for "ordinary, reasonable, and prudent" as a mis-stroke
- Fix `OERPBT` entry in `dict.json` to have value "interior"
- Have the Gutenberg dictionary prefer the single stroke `OERPBT` outline for "interior"