### PR TITLE
"Two-word briefs How *" lesson fix

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -268,6 +268,7 @@
 "HOPB/ORBL": "honorable",
 "HORS/PWABG": "horseback",
 "HOUD/*ER": "louder",
+"HOULD": "how old",
 "HR*ES": "LESS",
 "HRAEUD/EUS/AE": "lady's",
 "HRAO*EGT": "letting",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -24580,7 +24580,7 @@
 "HOUL": "howl",
 "HOUL/-G": "howling",
 "HOUL/SKWROL/KWREU": "Howell-Jolly",
-"HOULD": "how old",
+"HOULD": "how would",
 "HOULDZ": "How would",
 "HOULT": "how late",
 "HOUP": "hold up",


### PR DESCRIPTION
This is an issue found in Typey Type's [Two-word briefs How * lesson](https://didoesdigital.com/typey-type/lessons/collections/two-word-briefs-same-beginnings/how/).

Outline `HOULD` outputs "how would", rather than "how old", therefore, this PR proposes to:

- Mark `HOULD` for "how old" as a mis-stroke
- Fix `HOULD` entry in `dict.json` to have value "how would"