### PR TITLE
"Two-word briefs Where *" fix

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -1171,6 +1171,7 @@
 "WOR/TH*EU/ER": "worthier",
 "WOR/THEU/*PBS": "worthiness",
 "WORBG/PHEPB/SH-P": "workmanship",
+"WRELS": "where else",
 "WROPBG/KWROEL": "bronchiole",
 "WUP/PWORD": "cupboard",
 "WUPBT": "wasn't",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -138674,7 +138674,7 @@
 "WREFRPBS": "with reference",
 "WREFT": "wrest",
 "WREFT/HRER": "wrestler",
-"WRELS": "where else",
+"WRELS": "elsewhere",
 "WREPB": "wren",
 "WREPB/*FP": "wrench",
 "WREPB/*FPD": "wrenched",


### PR DESCRIPTION
While doing the ["Two-word briefs Where *" lesson](https://didoesdigital.com/typey-type/lessons/collections/two-word-briefs-same-beginnings/where/) on Typey Type, I found an entry that looks like it's been updated in Plover, so this PR proposes to add that update to the dictionaries.