### PR TITLE
"Two-word briefs Of *" fix

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -816,6 +816,7 @@
 "TEUPBG/WEURB": "distinguish",
 "TH-PL": "{.}",
 "THA/RA": "that are",
+"THAF": "of that",
 "THAFP": "that{.}",
 "THAOEDZ": "needs",
 "THAOEFRT/K-L": "theatrical",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -108306,7 +108306,7 @@
 "THAEURB": "their",
 "THAEURP": "therapy",
 "THAEURS": "theirs",
-"THAF": "of that",
+"THAF": "that've",
 "THAFLT": "that{.}",
 "THAFP": "that much",
 "THAFP/*ER": "Thatcher",


### PR DESCRIPTION
While doing the ["Two-word briefs Of *" lesson](https://didoesdigital.com/typey-type/lessons/collections/two-word-briefs-same-beginnings/of/) on Typey Type, I found an entry that looks like it's been updated in Plover, so this PR proposes to add that update to the dictionaries.