### PR TITLE
"Two word briefs * in" fixes

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -991,6 +991,7 @@
 "TPHAEUGS/-S": "nations",
 "TPHALT": "{^ality}",
 "TPHAOUS/KWRAFT": "enthusiast",
+"TPHAPS": "happens in",
 "TPHAT/TPHAT": "Nat",
 "TPHEF": "never",
 "TPHEFB": "nerve",

--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -990,6 +990,7 @@
 "TPHAER": "{^ary}",
 "TPHAEUGS/-S": "nations",
 "TPHALT": "{^ality}",
+"TPHAOEPL": "people in",
 "TPHAOUS/KWRAFT": "enthusiast",
 "TPHAPS": "happens in",
 "TPHAT/TPHAT": "Nat",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -126690,7 +126690,7 @@
 "TPHAPL/EL": "enamel",
 "TPHAPLS": "unanimous",
 "TPHAPLTS": "in a minute{,}please",
-"TPHAPS": "happens in",
+"TPHAPS": "naps",
 "TPHAR": "nar",
 "TPHAR/AEUGS": "narration",
 "TPHAR/AEUT": "narrate",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -125990,7 +125990,7 @@
 "TPHAOEPBS": "means that",
 "TPHAOEPBT": "nineteenth",
 "TPHAOEPD": "NYPD",
-"TPHAOEPL": "people in",
+"TPHAOEPL": "anemia",
 "TPHAOEPL/A*PB/PHARBG/SKWRUS": "Nieman Marcus",
 "TPHAOEPL/TOED": "nematode",
 "TPHAOER": "near",


### PR DESCRIPTION
While doing the ["Two-word briefs * in" lesson](https://didoesdigital.com/typey-type/lessons/collections/two-word-briefs-same-endings/in/) on Typey Type, I found some entries that look like they've been updated in Plover, so this PR proposes to add those updates to the dictionaries.