### PR TITLE
"Two word briefs * of" fixes

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -590,6 +590,7 @@
 "PWUT/PHEULG": "buttermilk",
 "R-S": "{^s are}",
 "R0S/2ER": "roster",
+"RAEUFT": "rate of",
 "RAF/AOUPBLG": "refuge",
 "RAOUBG/RAT/EUF": "lucrative",
 "RAOURB/KAEUT/-G": "lubricating",

--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -632,6 +632,7 @@
 "SAOER/KWRUS/HREU": "seriously",
 "SAOER/KWRUS/TPHES": "seriousness",
 "SAOERL": "seller",
+"SAOEUFD": "side of",
 "SAOEULG/SPORB": "cyclosporin",
 "SAOUPS": "{super^}",
 "SAT/APB": "Satan",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -74546,7 +74546,7 @@
 "RAEUFPB/-S/KROFT": "Ravenscroft",
 "RAEUFR": "racer",
 "RAEUFS": "raves",
-"RAEUFT": "rate of",
+"RAEUFT": "racist",
 "RAEUG/A*PB": "Reagan",
 "RAEUG/APBT": "Reagan",
 "RAEUG/TPHOPL/EUBGS": "Reaganomics",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -83310,7 +83310,7 @@
 "SAOEUF/ERS": "ciphers",
 "SAOEUF/O*PB": "siphon",
 "SAOEUF/OPBG": "siphoning",
-"SAOEUFD": "side of",
+"SAOEUFD": "sized",
 "SAOEUFG": "sizing",
 "SAOEUFPB": "siphon",
 "SAOEUFPB/-D": "siphoned",


### PR DESCRIPTION
While doing the ["Two-word briefs * of" lesson](https://didoesdigital.com/typey-type/lessons/collections/two-word-briefs-same-endings/of/) on Typey Type, I found some entries that look like they've been updated in Plover, so this PR proposes to add those updates to the dictionaries.