### PR TITLE
Add condensed stroke for "assets and liabilities"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1206,6 +1206,7 @@
 "S-P/EUFT": "ist",
 "S-PBT/TPHES": "isn't necessary",
 "S-PBZ": "seasons",
+"SA*ETS/SKP/HRAOEUBLTS": "assets and liabilities",
 "SABG/-FL": "sackful",
 "SABG/-S/-FL": "sacksful",
 "SAEUPBT/HREU": "saintly",


### PR DESCRIPTION
This PR proposes to add a condensed stroke for "assets and liabilities", `SA*ETS/SKP/HRAOEUBLTS`, that uses the `SA*ETS` single-stroke outline for "assets".