### PR TITLE
Add `PHEUBG/*L` outline for "Mikel"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -861,7 +861,7 @@
 "PHER/PHA*PB": "merman",
 "PHER/REU/PHA*EUBG/-G": "merrymaking",
 "PHEU/THOLG/-S": "mythologies",
-"PHEUBG/*L": "mickle",
+"PHEUBG/TK-LS/HR*/*E": "mickle",
 "PHEUGS/REU/-S": "missionaries",
 "PHEUL/*ERS": "millers",
 "PHEUZ/HRAED": "mislead",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -57770,6 +57770,7 @@
 "PHEU/TPHUS/KAOUL": "minuscule",
 "PHEU/TPHUTS": "minutes",
 "PHEUBG": "mick",
+"PHEUBG/*L": "Mikel",
 "PHEUBG/AO*EL": "micelle",
 "PHEUBG/AOEUL": "Mikhail",
 "PHEUBG/APBG": "Michelangelo",


### PR DESCRIPTION
Outline `PHEUBG/*L` has a Plover entry to output the name "Mikel", therefore, this PR proposes to:

- Add `PHEUBG/*L` for "Mikel" to `dict.json`
- Change condensed stroke for "mickle" from `PHEUBG/*L` to
  `PHEUBG/TK-LS/HR*/*E`