### PR TITLE
Add plover outlines

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -133835,6 +133835,7 @@
 "TROUPBG": "Truong",
 "TROURPB": "return to",
 "TROURPBS": "returns to",
+"TROURS": "trouser",
 "TROURT": "trial court",
 "TROUS": "introduces",
 "TROUS/*ER": "trouser",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -33866,6 +33866,7 @@
 "KH*EUL/PWHRAEUPB": "chilblain",
 "KH*EUL/SKWRE": "Chile",
 "KH*EUP/TKAEUL": "Chippendale",
+"KH*EUPB": "chicken",
 "KH*EUPBG": "chink",
 "KH*EUPL": "chimp",
 "KH*EUPL/A*PB/SAO*E": "chimpanzee",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -52751,6 +52751,7 @@
 "PH*EG/TPOEPB": "megaphone",
 "PH*EG/TREPBD": "megatrend",
 "PH*EG/TREPBDZ": "megatrends",
+"PH*EGT": "magnetic",
 "PH*EL": "Mel",
 "PH*EL/HROPB": "Mellon",
 "PH*EL/O*PB": "melon",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8614,7 +8614,7 @@
 "PUD/-G": "pudding",
 "SROL/KAPBG": "volcanic",
 "HRO*BG": "Locke",
-"PHAPBG/EUBG": "magnetic",
+"PH*EGT": "magnetic",
 "TKAOELS": "deals",
 "KOR": "core",
 "TKAOEPBS/SEU": "decency",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -6161,7 +6161,7 @@
 "PHAPBT/*L": "mantle",
 "TPH*/*E/AE/*ER": "ne'er",
 "STKUFG": "discussing",
-"KHEU/KEPB": "chicken",
+"KH*EUPB": "chicken",
 "SKWREURBL": "judicial",
 "KAOPBT": "consistent",
 "REULG": "ridicule",


### PR DESCRIPTION
This PR proposes to add some Plover outlines for "chicken", "trouser", and "magnetic" into the main dictionary, and have the Gutenberg dictionary prefer the single-stroke outlines for "chicken" and "magnetic".