### PR TITLE
Add one-stroke `TRAFRLS` condensed stroke outline for "travelers"

### DIFF
--- a/dictionaries/condensed-strokes.json
+++ b/dictionaries/condensed-strokes.json
@@ -1772,6 +1772,7 @@
 "TRA*FL/HRER": "traveller",
 "TRAFL/*LD": "travelled",
 "TRAFL/HREUPBG": "travelling",
+"TRAFLRS": "travelers",
 "TRAOEULS/SKP/TREUBL/AEUGS/-S": "trials and tribulations",
 "TRAPB/KWEUL/HREU": "tranquilly",
 "TRAPBZ/HRAEUBGS/-S": "translations",

--- a/dictionaries/dict-en-AU-with-extra-stroke.json
+++ b/dictionaries/dict-en-AU-with-extra-stroke.json
@@ -2489,6 +2489,7 @@
 "TRAFL/HROG/A*U": "travelogue",
 "TRAFLD/A*U": "travelled",
 "TRAFLG/A*U": "travelling",
+"TRAFLRS/A*U": "travellers",
 "TRAFT/A*U": "draught",
 "TRAL/AOEUFD/A*U": "centralised",
 "TRAOEUF/ERS/AE/HRAEU/SEPB/A*U": "driver's licence",


### PR DESCRIPTION
This PR proposes to add a one-stroke `TRAFRLS` condensed stroke outline for "travelers" and an AU stroke based on it.