### PR TITLE
Add Plover outline `TKAEPL` for "damn"

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -110062,6 +110062,7 @@
 "TKAEL": "dale",
 "TKAELT": "data",
 "TKAEPBT": "dependent",
+"TKAEPL": "damn",
 "TKAER": "dear",
 "TKAER/SRERPB/KA": "Dear Veronica",
 "TKAERBG/KWRO": "{dacryo^}",

--- a/dictionaries/top-10000-project-gutenberg-words.json
+++ b/dictionaries/top-10000-project-gutenberg-words.json
@@ -8117,7 +8117,7 @@
 "HEPL": "hem",
 "TKPWORPBLG": "gorge",
 "PWAP/TAOEUZ/-D": "baptized",
-"TKA*EPL": "damn",
+"TKAEPL": "damn",
 "SEUL/SRER/KWREU": "silvery",
 "PAS/TOR": "pastor",
 "EUPB/HERPBT": "inherent",


### PR DESCRIPTION
This PR proposes to add the Plover outline `TKAEPL` for "damn" and have the Gutenberg dictionary prefer it.