### PR TITLE
Add `HR*UFRPB` Plover outline for "lunch".

### DIFF
--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -24891,6 +24891,7 @@
 "HR*UF/TKPWHREU": "lovingly",
 "HR*UFBL": "lovable",
 "HR*UFR": "lover",
+"HR*UFRPB": "lunch",
 "HR*UP": "lineup",
 "HR*UPBGS": "luncheon",
 "HR*UPL": "lump",


### PR DESCRIPTION
This PR proposes to add the `HR*UFRPB` Plover outline for "lunch" to `dict.json`.