### PR TITLE
Mark `PHA/POEL/KWROPB` for "Napoleon" as a mis-stroke.

### DIFF
--- a/dictionaries/bad-habits.json
+++ b/dictionaries/bad-habits.json
@@ -459,6 +459,7 @@
 "PH-PBLG/TPHAEUGS": "imagination",
 "PH-PT": "Manhattan",
 "PHA*EUBG/-G": "{^making}",
+"PHA/POEL/KWROPB": "Napoleon",
 "PHAD/APL": "madam",
 "PHAEZ/-Z": "phases",
 "PHAFRP/-G": "marching",

--- a/dictionaries/dict.json
+++ b/dictionaries/dict.json
@@ -53578,7 +53578,6 @@
 "PHA/PHARBGS": "Mama{,}",
 "PHA/PHEUL/HRA": "mamilla",
 "PHA/PHOG/RA/TPEU": "mammography",
-"PHA/POEL/KWROPB": "Napoleon",
 "PHA/RA/KA": "maraca",
 "PHA/RA/SKWRA": "maharaja",
 "PHA/RAEUR/KWRAL": "malarial",


### PR DESCRIPTION
Although it is a valid Plover outline, this PR proposes to mark `PHA/POEL/KWROPB` for "Napoleon" as a mis-stroke, since it pronounces as "Mapoleon", and all the other outlines for "Napoleon" contain the correct first stroke `TPHA`.