### PR TITLE
Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure that Github reports that this repo contains JSON.
+*.json linguist-detectable


### PR DESCRIPTION
This PR proposes a simple "quality-of-life" addition that adds a `.gitattributes` file so that Github (read: [Linguist](https://github.com/github/linguist)) reports that this repo uses JSON as its primary language.

See an example of what that looks like on [my steno dictionaries repo](https://github.com/paulfioravanti/steno_dictionaries): you'll see it reports the Languages to be "JSON 100%".